### PR TITLE
quick install without core.git download and use install.php

### DIFF
--- a/client_files/mediawiki-quick.sh
+++ b/client_files/mediawiki-quick.sh
@@ -46,9 +46,9 @@ composer update
 # Download Vector skin tarball, REL1_25 branch
 #
 cd skins
-https://github.com/wikimedia/mediawiki-skins-Vector/archive/REL1_25.zip
+wget https://github.com/wikimedia/mediawiki-skins-Vector/archive/REL1_25.tar.gz
 mkdir Vector
-tar xpvf meza1.tar.gz -C ./Vector --strip-components 1
+tar xpvf mediawiki-skins-Vector-REL1_25.tar.gz -C ./Vector --strip-components 1
 
 
 #

--- a/client_files/mediawiki-quick.sh
+++ b/client_files/mediawiki-quick.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Setup MediaWiki (quick--not checking out whole core.git)
+#
+# Example:
+#   bash mediawiki-quick.sh <mysql-root-pass> <wiki-admin-pass>
+#
+#   $1: mysql-root-pass: the password for your mysql root user
+#   $2: wiki-admin-pass: the user "Admin" will be created for this wiki
+#       and this will be used as Admin's password
+#
+
+
+#
+# Install Composer
+#
+cd ~/sources
+curl -sS https://getcomposer.org/installer | php
+mv composer.phar /usr/local/bin/composer
+
+
+#
+# Download MediaWiki from tarball
+#
+cd /var/www/meza1/htdocs
+wget http://releases.wikimedia.org/mediawiki/1.25/mediawiki-core-1.25.1.tar.gz
+
+mkdir wiki
+tar xpvf mediawiki-core-1.25.1.tar.gz -C ./wiki --strip-components 1
+cd wiki
+
+
+#
+# Give apache the right to modify images
+#
+chown -R apache:www ./images
+
+
+#
+# Update Composer dependencies
+#
+composer update
+
+
+#
+# Download Vector skin tarball, REL1_25 branch
+#
+cd skins
+https://github.com/wikimedia/mediawiki-skins-Vector/archive/REL1_25.zip
+mkdir Vector
+tar xpvf meza1.tar.gz -C ./Vector --strip-components 1
+
+
+#
+# Install MW with install.php
+#
+cd ..
+php maintenance/install.php \
+	--dbtype mysql \
+	--dbuser root \
+	--dbpass "$1" \
+	--dbname wiki_test \
+	--pass "$2" \
+	TestWiki Admin \
+	--scriptpath /wiki
+


### PR DESCRIPTION
This pull request adds one file, mediawiki-quick.sh. The file is very similar to mediawiki.sh, but instead of checking out MediaWiki core from a git repository, the tarball for MW 1.25.1 is simply downloaded. This makes the install much faster. The Vector skin is also downloaded as tarball instead of git-cloned.

MediaWiki installation is then performed using the maintenance script install.php. Usage of this script requires two parameters to be passed: the mysql root password and the password for the wiki's Admin account (e.g. username = "Admin"). Usage is as follows:

```bash mediawiki-quick.sh <mysql-root-pass> <wiki-admin-pass>```

This script installs a wiki called TestWiki to a database named wiki_test.