### PR TITLE
Add PECL internationalization extension to php.sh

### DIFF
--- a/client_files/php.sh
+++ b/client_files/php.sh
@@ -82,6 +82,7 @@ cd "php-$phpversion/"
     --enable-mbregex \
     --enable-opcache \
     --enable-fpm \
+    --enable-intl \
     --prefix=/usr/local/php
 make
 make install


### PR DESCRIPTION
On install of MediaWiki a warning is issued stating that MediaWiki will fall back on its own internationalization functions rather than using the more efficient PECL versions. See issue #17.