### PR TITLE
Install VE

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,10 @@ To get some extensions installed, try the following using an experimental MediaW
 ```bash
 bash ~/sources/meza1/client_files/extensions.sh
 ```
+
+## Install Visual Editor
+To install Visual Editor, use the following command:
+
+```bash
+bash ~/sources/meza1/client_files/VE.sh
+```

--- a/client_files/ExtensionSettingsVE.php
+++ b/client_files/ExtensionSettingsVE.php
@@ -4,7 +4,7 @@ $egExtensionLoaderConfig += array(
 	'UniversalLanguageSelector' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git',
 		'branch' => 'REL1_25',
-	), " >> ~/sources/meza1/client_files/ExtensionSettings.php
+	),
 	'VisualEditor' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git',
 		'branch' => 'REL1_25',

--- a/client_files/ExtensionSettingsVE.php
+++ b/client_files/ExtensionSettingsVE.php
@@ -1,3 +1,5 @@
+
+# Add 2 extensions required for VE
 $egExtensionLoaderConfig += array(
 	'UniversalLanguageSelector' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git',
@@ -8,3 +10,5 @@ $egExtensionLoaderConfig += array(
 		'branch' => 'REL1_25',
 	),
 );
+
+# End of VE additions

--- a/client_files/ExtensionSettingsVE.php
+++ b/client_files/ExtensionSettingsVE.php
@@ -1,0 +1,10 @@
+$egExtensionLoaderConfig += array(
+	'UniversalLanguageSelector' => array(
+		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git',
+		'branch' => 'REL1_25',
+	), " >> ~/sources/meza1/client_files/ExtensionSettings.php
+	'VisualEditor' => array(
+		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git',
+		'branch' => 'REL1_25',
+	),
+);

--- a/client_files/LocalSettingsVE.php
+++ b/client_files/LocalSettingsVE.php
@@ -1,8 +1,5 @@
 
-// Begin info for VE
-//require_once "$IP/extensions/UniversalLanguageSelector/UniversalLanguageSelector.php";
-
-//require_once "$IP/extensions/VisualEditor/VisualEditor.php";
+// ******* Begin info for VE *******
 
 // Enable by default for everybody
 $wgDefaultUserOptions['visualeditor-enable'] = 1;
@@ -22,4 +19,4 @@ $wgVisualEditorParsoidURL = 'http://127.0.0.1:8000';
 // Parsoid will be called as $url/$prefix/$pagename
 $wgVisualEditorParsoidPrefix = 'wiki';
 
-// End info for VE
+// ******* End info for VE *******

--- a/client_files/LocalSettingsVE.php
+++ b/client_files/LocalSettingsVE.php
@@ -1,3 +1,5 @@
+
+// Begin info for VE
 //require_once "$IP/extensions/UniversalLanguageSelector/UniversalLanguageSelector.php";
 
 //require_once "$IP/extensions/VisualEditor/VisualEditor.php";
@@ -19,3 +21,5 @@ $wgVisualEditorParsoidURL = 'http://127.0.0.1:8000';
 // Interwiki prefix to pass to the Parsoid instance
 // Parsoid will be called as $url/$prefix/$pagename
 $wgVisualEditorParsoidPrefix = 'wiki';
+
+// End info for VE

--- a/client_files/LocalSettingsVE.php
+++ b/client_files/LocalSettingsVE.php
@@ -1,6 +1,6 @@
-require_once "$IP/extensions/UniversalLanguageSelector/UniversalLanguageSelector.php";
+//require_once "$IP/extensions/UniversalLanguageSelector/UniversalLanguageSelector.php";
 
-require_once "$IP/extensions/VisualEditor/VisualEditor.php";
+//require_once "$IP/extensions/VisualEditor/VisualEditor.php";
 
 // Enable by default for everybody
 $wgDefaultUserOptions['visualeditor-enable'] = 1;

--- a/client_files/LocalSettingsVE.php
+++ b/client_files/LocalSettingsVE.php
@@ -1,0 +1,21 @@
+require_once "$IP/extensions/UniversalLanguageSelector/UniversalLanguageSelector.php";
+
+require_once "$IP/extensions/VisualEditor/VisualEditor.php";
+
+// Enable by default for everybody
+$wgDefaultUserOptions['visualeditor-enable'] = 1;
+
+// Don't allow users to disable it
+$wgHiddenPrefs[] = 'visualeditor-enable';
+
+// OPTIONAL: Enable VisualEditor's experimental code features
+#$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
+
+// URL to the Parsoid instance
+// MUST NOT end in a slash due to Parsoid bug
+// Use port 8142 if you use the Debian package
+$wgVisualEditorParsoidURL = 'http://127.0.0.1:8000';
+
+// Interwiki prefix to pass to the Parsoid instance
+// Parsoid will be called as $url/$prefix/$pagename
+$wgVisualEditorParsoidPrefix = 'wiki';

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -72,7 +72,6 @@ chkconfig --add /etc/init.d/parsoid
 echo "******* Starting parsoid server *******"
 #chkconfig parsoid on # @todo: not required?
 service parsoid start
-sleep 10  # Waits 10 seconds
 echo "******* Please test VE in your wiki *******"
 
 # Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -50,6 +50,12 @@ echo "******* Installing VE *******"
 cd /var/www/meza1/htdocs/wiki/extensions/VisualEditor
 git submodule update --init
 
+# Any time you run updateExtensions.php it may be required to run
+# `php maintenance/update.php` since new extension versions may be installed
+echo "******* Running update.php to update database as required *******"
+cd /var/www/meza1/htdocs/wiki/maintenance
+php update.php
+
 # Create parsoid user to run parsoid node server
 cd /etc/parsoid # @issue#48: is this necessary?
 useradd parsoid

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -6,7 +6,7 @@ cd ~/sources
 wget https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz
 tar zxvf node-v0.12.5.tar.gz
 cd node-v0.12.5
-./configure --prefix=/etc/mediawiki/parsoid
+./configure --prefix=/etc/mediawiki/node
 make
 make install
 
@@ -22,12 +22,19 @@ npm test #optional?
 
 # Configure parsoid for wiki use
 # This part can be modified once localsettings.js is included in initial download of files
-cd ~/sources
-wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/client_files/localsettings.js
+# TODO change client_files to master once merged
+# localsettings for parsoid
+cd ~/sources/meza1/client_files
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/localsettings.js
 cp localsettings.js /etc/mediawiki/parsoid/api/localsettings.js
-wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/client_files/ExtensionSettingsVE.php
+# Add VE and UniversalLanguageSelector to ExtensionSettings
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/ExtensionSettingsVE.php
 cp ExtensionSettingsVE.php /var/www/meza1/htdocs/wiki/ExtensionSettingsVE.php
-wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/client_files/LocalSettingsVE.php
+cat /var/www/meza1/htdocs/wiki/ExtensionSettingsVE.php >> /var/www/meza1/htdocs/wiki/ExtensionSettings.php
+# Add VE settings to LocalSettings.php
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/LocalSettingsVE.php
+cp LocalSettingsVE.php /var/www/meza1/htdocs/wiki/LocalSettingsVE.php
+cat /var/www/meza1/htdocs/wiki/LocalSettingsVE.php >> /var/www/meza1/htdocs/wiki/LocalSettings.php
 
 # Run updateExtensions to install UniversalLanguageSelector and VisualEditor
 php /var/www/meza1/htdocs/wiki/extensions/ExtensionLoader/updateExtensions.php
@@ -36,8 +43,6 @@ cd /usr/var/meza1/htdocs/wiki/extensions/VisualEditor
 # Will this git command work with the way ExtensionLoader installs the extension?
 git submodule update --init
 
-# Add VE settings to LocalSettings.php
-cat ~/sources/LocalSettingsVE.php >> /var/www/meza1/htdocs/wiki/LocalSettings.php
 
 # Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
 

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -1,22 +1,27 @@
 
-
+echo "*** Downloading node.js ***"
 cd ~/sources
 
 # Download, compile, and install node
 wget https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz
 tar zxvf node-v0.12.5.tar.gz
 cd node-v0.12.5
-./configure --prefix=/etc/mediawiki/node
+./configure
+echo "*** Compiling node.js ***"
 make
+echo "*** Installing node.js ***"
 make install
 
-# Download and install parsoid
+# Download and install parsoid\
+echo "*** Downloading parsoid ***"
 cd /etc/mediawiki
 git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
 cd parsoid
+echo "*** Installing parsoid ***"
 npm install
 # npm install results in "npm WARN prefer global jshint@2.8.0 should be installed with -g"
 
+echo "*** Testing parsoid ***"
 npm test #optional?
 # several warnings come out of npm test
 
@@ -24,6 +29,7 @@ npm test #optional?
 # This part can be modified once localsettings.js is included in initial download of files
 # TODO change client_files to master once merged
 # localsettings for parsoid
+echo "*** Downloading configuration files ***"
 cd ~/sources/meza1/client_files
 wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/localsettings.js
 cp localsettings.js /etc/mediawiki/parsoid/api/localsettings.js
@@ -37,8 +43,10 @@ cp LocalSettingsVE.php /var/www/meza1/htdocs/wiki/LocalSettingsVE.php
 cat /var/www/meza1/htdocs/wiki/LocalSettingsVE.php >> /var/www/meza1/htdocs/wiki/LocalSettings.php
 
 # Run updateExtensions to install UniversalLanguageSelector and VisualEditor
+echo "*** Installing extensions ***"
 php /var/www/meza1/htdocs/wiki/extensions/ExtensionLoader/updateExtensions.php
 
+echo "*** Installing VE ***"
 cd /usr/var/meza1/htdocs/wiki/extensions/VisualEditor
 # Will this git command work with the way ExtensionLoader installs the extension?
 git submodule update --init
@@ -47,6 +55,7 @@ git submodule update --init
 # Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
 
 # Start the server
+echo "*** Starting parsoid server ***"
 node ~/sources/parsoid/api/server.js
 
 # Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -83,6 +83,7 @@ chkconfig --add /etc/init.d/parsoid
 echo "******* Starting parsoid server *******"
 #chkconfig parsoid on
 service parsoid start
+echo "******* Please test VE in your wiki *******"
 
 # Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)
 # but you can use curl 127.0.0.1:8000 in ssh to verify it works

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -13,7 +13,7 @@ make
 echo "******* Installing node.js *******"
 make install
 
-# Download and install parsoid\
+# Download and install parsoid
 echo "******* Downloading parsoid *******"
 cd /etc
 git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
@@ -34,16 +34,13 @@ npm test #optional?
 # localsettings for parsoid
 echo "******* Downloading configuration files *******"
 cd ~/sources/meza1/client_files
-wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/localsettings.js
-cp localsettings.js /etc/parsoid/api/localsettings.js
+
+# Copy Parsoid settings from Meza to Parsoid install
+cp ./localsettings.js /etc/parsoid/api/localsettings.js
 # Add VE and UniversalLanguageSelector to ExtensionSettings
-wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/ExtensionSettingsVE.php
-cp ExtensionSettingsVE.php /var/www/meza1/htdocs/wiki/ExtensionSettingsVE.php
-cat /var/www/meza1/htdocs/wiki/ExtensionSettingsVE.php >> /var/www/meza1/htdocs/wiki/ExtensionSettings.php
+cat ./ExtensionSettingsVE.php >> /var/www/meza1/htdocs/wiki/ExtensionSettings.php
 # Add VE settings to LocalSettings.php
-wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/LocalSettingsVE.php
-cp LocalSettingsVE.php /var/www/meza1/htdocs/wiki/LocalSettingsVE.php
-cat /var/www/meza1/htdocs/wiki/LocalSettingsVE.php >> /var/www/meza1/htdocs/wiki/LocalSettings.php
+cat ./LocalSettingsVE.php >> /var/www/meza1/htdocs/wiki/LocalSettings.php
 
 # Run updateExtensions to install UniversalLanguageSelector and VisualEditor
 echo "******* Installing extensions *******"
@@ -51,18 +48,10 @@ php /var/www/meza1/htdocs/wiki/extensions/ExtensionLoader/updateExtensions.php
 
 echo "******* Installing VE *******"
 cd /var/www/meza1/htdocs/wiki/extensions/VisualEditor
-# Will this git command work with the way ExtensionLoader installs the extension?
 git submodule update --init
 
-
-# Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
-
-# Start the server
-#echo "******* Starting parsoid server *******"
-#node /etc/parsoid/api/server.js
-
 # Create parsoid user to run parsoid node server
-cd /etc/parsoid #not sure if this is necessary
+cd /etc/parsoid # @issue#48: is this necessary?
 useradd parsoid
 
 # Grant parsoid user ownership of /opt/services/parsoid
@@ -73,17 +62,15 @@ chown parsoid:parsoid /etc/parsoid -R
 # http://www.tldp.org/HOWTO/HighQuality-Apps-HOWTO/boot.html
 # https://github.com/narath/brigopedia#setup-visualeditor-extension
 # Create service script
-echo "******* Creaing parsoid service *******"
+echo "******* Creating parsoid service *******"
 cd ~/sources/meza1/client_files
-# TODO This part can be modified once localsettings.js is included in initial download of files
-wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/initd_parsoid.sh
-cp initd_parsoid.sh /etc/init.d/parsoid
+cp ./initd_parsoid.sh /etc/init.d/parsoid
 chmod 755 /etc/init.d/parsoid
 chkconfig --add /etc/init.d/parsoid
 
 # Start parsoid service
 echo "******* Starting parsoid server *******"
-#chkconfig parsoid on
+#chkconfig parsoid on # @todo: not required?
 service parsoid start
 sleep 10  # Waits 10 seconds
 echo "******* Please test VE in your wiki *******"

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -6,185 +6,50 @@ cd ~/sources
 wget https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz
 tar zxvf node-v0.12.5.tar.gz
 cd node-v0.12.5
-./configure
+./configure --prefix=/etc/mediawiki/parsoid
 make
 make install
 
 # Download and install parsoid
-cd ..
+cd /etc/mediawiki
 git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
 cd parsoid
 npm install
-
---> npm WARN prefer global jshint@2.8.0 should be installed with -g
+# npm install results in "npm WARN prefer global jshint@2.8.0 should be installed with -g"
 
 npm test #optional?
-
---> several warnings
+# several warnings come out of npm test
 
 # Configure parsoid for wiki use
-cd api
+# This part can be modified once localsettings.js is included in initial download of files
+cd ~/sources
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/client_files/localsettings.js
+cp localsettings.js /etc/mediawiki/parsoid/api/localsettings.js
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/client_files/ExtensionSettingsVE.php
+cp ExtensionSettingsVE.php /var/www/meza1/htdocs/wiki/ExtensionSettingsVE.php
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/client_files/LocalSettingsVE.php
 
-
-*** use CLI to create localsettings.js with this content:
-
-'use strict';
-
-exports.setup = function(parsoidConfig) {
-	// Set your own user-agent string
-	// Otherwise, defaults to "Parsoid/<current-version-defined-in-package.json>"
-	//parsoidConfig.userAgent = "My-User-Agent-String";
-
-	// The URL of your MediaWiki API endpoint.
-	parsoidConfig.setMwApi('MezaWiki', { uri: 'http://192.168.56.58/wiki/api.php' });
-	// To specify a proxy (or proxy headers) specific to this prefix (which
-	// overrides defaultAPIProxyURI) use:
-	/*
-	parsoidConfig.setMwApi('localhost', {
-		uri: 'http://localhost/w/api.php',
-		// set `proxy` to `null` to override and force no proxying.
-		proxy: {
-			uri: 'http://my.proxy:1234/',
-			headers: { 'X-Forwarded-Proto': 'https' } // headers are optional
-		}
-	});
-	*/
-
-	// We pre-define wikipedias as 'enwiki', 'dewiki' etc. Similarly
-	// for other projects: 'enwiktionary', 'enwikiquote', 'enwikibooks',
-	// 'enwikivoyage' etc. (default true)
-	//parsoidConfig.loadWMF = false;
-
-	// A default proxy to connect to the API endpoints.
-	// Default: undefined (no proxying).
-	// Overridden by per-wiki proxy config in setMwApi.
-	//parsoidConfig.defaultAPIProxyURI = 'http://proxy.example.org:8080';
-
-	// Enable debug mode (prints extra debugging messages)
-	//parsoidConfig.debug = true;
-
-	// Use the PHP preprocessor to expand templates via the MW API (default true)
-	//parsoidConfig.usePHPPreProcessor = false;
-
-	// Use selective serialization (default false)
-	parsoidConfig.useSelser = true;
-
-	// Allow cross-domain requests to the API (default '*')
-	// Sets Access-Control-Allow-Origin header
-	// disable:
-	//parsoidConfig.allowCORS = false;
-	// restrict:
-	//parsoidConfig.allowCORS = 'some.domain.org';
-
-	// Set to true for using the default performance metrics reporting to statsd
-	// If true, provide the statsd host/port values
-	/*
-	parsoidConfig.useDefaultPerformanceTimer = true;
-	parsoidConfig.txstatsdHost = 'statsd.domain.org';
-	parsoidConfig.txstatsdPort = 8125;
-	*/
-
-	// Alternatively, define performanceTimer as follows:
-	/*
-	parsoidConfig.performanceTimer = {
-		timing: function(metricName, time) { }, // do-something-with-it
-		count: function(metricName, value) { }, // do-something-with-it
-	};
-	*/
-
-	// How often should we emit a heap sample? Time in ms.
-	// This setting is only relevant if you have enabled
-	// performance monitoring either via the default metrics
-	// OR by defining your own performanceTimer properties
-	//parsoidConfig.heapUsageSampleInterval = 5 * 60 * 1000;
-
-	// Allow override of port/interface:
-	//parsoidConfig.serverPort = 8000;
-	//parsoidConfig.serverInterface = '127.0.0.1';
-
-	// The URL of your LintBridge API endpoint
-	//parsoidConfig.linterAPI = 'http://lintbridge.wmflabs.org/add';
-
-	// Require SSL certificates to be valid (default true)
-	// Set to false when using self-signed SSL certificates
-	//parsoidConfig.strictSSL = false;
-
-	// Use a different server for CSS style modules.
-	// Set to true to use bits.wikimedia.org, or to a string with the URI.
-	// Leaving it undefined (the default) will use the same URI as the MW API,
-	// changing api.php for load.php.
-	//parsoidConfig.modulesLoadURI = true;
-
-	// Suppress some warnings from the Mediawiki API
-	// (defaults to suppressing warnings which the Parsoid team knows to
-	// be harmless)
-	//parsoidConfig.suppressMwApiWarnings = /annoying warning|other warning/;
-};
-
-***
-
-Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
-
-
-# Start the server
-cd .. (to parsoid dir)
-node api/server.js
-
-Note that you can't access the parsoid service via 192.168.56.58:8000 (at least by default), but you can use curl 127.0.0.1:8000 to verify it works
-
-Need to replace or add after # Start the server with an automated way of starting the server (upon reboot)
-https://www.mediawiki.org/wiki/Parsoid/Developer_Setup#Starting_the_Parsoid_service_automatically
-
-
-# Install Extension:UniversalLanguageSelector
-
-echo " " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "\$egExtensionLoaderConfig += array( " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "	'UniversalLanguageSelector' => array( " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git', " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "		'branch' => 'REL1_25', " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "	), " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "	'VisualEditor' => array( " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git', " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "		'branch' => 'REL1_25', " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "	), " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "); " >> ~/sources/meza1/client_files/ExtensionSettings.php
-echo "" >> ~/sources/meza1/client_files/ExtensionSettings.php
-
+# Run updateExtensions to install UniversalLanguageSelector and VisualEditor
 php /var/www/meza1/htdocs/wiki/extensions/ExtensionLoader/updateExtensions.php
 
-
 cd /usr/var/meza1/htdocs/wiki/extensions/VisualEditor
+# Will this git command work with the way ExtensionLoader installs the extension?
 git submodule update --init
 
+# Add VE settings to LocalSettings.php
+cat ~/sources/LocalSettingsVE.php >> /var/www/meza1/htdocs/wiki/LocalSettings.php
 
-Note documentation for multi-language support configuration: https://www.mediawiki.org/wiki/Extension:UniversalLanguageSelector
+# Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
 
-# Add to LocalSettings.php
-some command ****
+# Start the server
+node ~/sources/parsoid/api/server.js
 
-require_once "$IP/extensions/VisualEditor/VisualEditor.php";
+# Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)
+# but you can use curl 127.0.0.1:8000 in ssh to verify it works
 
-// Enable by default for everybody
-$wgDefaultUserOptions['visualeditor-enable'] = 1;
+# Need to replace or add an automated way of starting the server (upon reboot)
+# https://www.mediawiki.org/wiki/Parsoid/Developer_Setup#Starting_the_Parsoid_service_automatically
 
-// Don't allow users to disable it
-$wgHiddenPrefs[] = 'visualeditor-enable';
+# Note documentation for multi-language support configuration: https://www.mediawiki.org/wiki/Extension:UniversalLanguageSelector
 
-// OPTIONAL: Enable VisualEditor's experimental code features
-#$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
-
-// URL to the Parsoid instance
-// MUST NOT end in a slash due to Parsoid bug
-// Use port 8142 if you use the Debian package
-$wgVisualEditorParsoidURL = 'http://localhost:8000';
-
-// Interwiki prefix to pass to the Parsoid instance
-// Parsoid will be called as $url/$prefix/$pagename
-$wgVisualEditorParsoidPrefix = 'MezaWiki';
-
-Note: Other extensions which load plugins for VE (e.g. Math) should be loaded after VE for those plugins to work.
-
-
-
-
+# Note: Other extensions which load plugins for VE (e.g. Math) should be loaded after VE for those plugins to work.

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -3,6 +3,7 @@ echo "******* Downloading node.js *******"
 cd ~/sources
 
 # Download, compile, and install node
+# Ref: https://www.digitalocean.com/community/tutorials/how-to-install-and-run-a-node-js-app-on-centos-6-4-64bit
 wget https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz
 tar zxvf node-v0.12.5.tar.gz
 cd node-v0.12.5
@@ -58,7 +59,14 @@ git submodule update --init
 #echo "******* Starting parsoid server *******"
 #node /etc/parsoid/api/server.js
 
-# Need to replace or add an automated way of starting the server (upon reboot)
+# Create parsoid user to run parsoid node server
+cd /etc/parsoid #not sure if this is necessary
+useradd parsoid
+
+# Grant parsoid user ownership of /opt/services/parsoid
+chown parsoid:parsoid /etc/parsoid -R
+
+# I used the following references for an automated service for starting parsoid on boot:
 # https://www.mediawiki.org/wiki/Parsoid/Developer_Setup#Starting_the_Parsoid_service_automatically
 # http://www.tldp.org/HOWTO/HighQuality-Apps-HOWTO/boot.html
 # https://github.com/narath/brigopedia#setup-visualeditor-extension
@@ -68,12 +76,13 @@ cd ~/sources/meza1/client_files
 # TODO This part can be modified once localsettings.js is included in initial download of files
 wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/initd_parsoid.sh
 cp initd_parsoid.sh /etc/init.d/parsoid
-chmod +x /etc/init.d/parsoid
+chmod 755 /etc/init.d/parsoid
+chkconfig --add /etc/init.d/parsoid
 
 # Start parsoid service
 echo "******* Starting parsoid server *******"
-chkconfig httpd on
-service httpd status
+#chkconfig parsoid on
+service parsoid start
 
 # Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)
 # but you can use curl 127.0.0.1:8000 in ssh to verify it works

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -1,0 +1,190 @@
+
+
+cd ~/sources
+
+# Download, compile, and install node
+wget https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz
+tar zxvf node-v0.12.5.tar.gz
+cd node-v0.12.5
+./configure
+make
+make install
+
+# Download and install parsoid
+cd ..
+git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
+cd parsoid
+npm install
+
+--> npm WARN prefer global jshint@2.8.0 should be installed with -g
+
+npm test #optional?
+
+--> several warnings
+
+# Configure parsoid for wiki use
+cd api
+
+
+*** use CLI to create localsettings.js with this content:
+
+'use strict';
+
+exports.setup = function(parsoidConfig) {
+	// Set your own user-agent string
+	// Otherwise, defaults to "Parsoid/<current-version-defined-in-package.json>"
+	//parsoidConfig.userAgent = "My-User-Agent-String";
+
+	// The URL of your MediaWiki API endpoint.
+	parsoidConfig.setMwApi('MezaWiki', { uri: 'http://192.168.56.58/wiki/api.php' });
+	// To specify a proxy (or proxy headers) specific to this prefix (which
+	// overrides defaultAPIProxyURI) use:
+	/*
+	parsoidConfig.setMwApi('localhost', {
+		uri: 'http://localhost/w/api.php',
+		// set `proxy` to `null` to override and force no proxying.
+		proxy: {
+			uri: 'http://my.proxy:1234/',
+			headers: { 'X-Forwarded-Proto': 'https' } // headers are optional
+		}
+	});
+	*/
+
+	// We pre-define wikipedias as 'enwiki', 'dewiki' etc. Similarly
+	// for other projects: 'enwiktionary', 'enwikiquote', 'enwikibooks',
+	// 'enwikivoyage' etc. (default true)
+	//parsoidConfig.loadWMF = false;
+
+	// A default proxy to connect to the API endpoints.
+	// Default: undefined (no proxying).
+	// Overridden by per-wiki proxy config in setMwApi.
+	//parsoidConfig.defaultAPIProxyURI = 'http://proxy.example.org:8080';
+
+	// Enable debug mode (prints extra debugging messages)
+	//parsoidConfig.debug = true;
+
+	// Use the PHP preprocessor to expand templates via the MW API (default true)
+	//parsoidConfig.usePHPPreProcessor = false;
+
+	// Use selective serialization (default false)
+	parsoidConfig.useSelser = true;
+
+	// Allow cross-domain requests to the API (default '*')
+	// Sets Access-Control-Allow-Origin header
+	// disable:
+	//parsoidConfig.allowCORS = false;
+	// restrict:
+	//parsoidConfig.allowCORS = 'some.domain.org';
+
+	// Set to true for using the default performance metrics reporting to statsd
+	// If true, provide the statsd host/port values
+	/*
+	parsoidConfig.useDefaultPerformanceTimer = true;
+	parsoidConfig.txstatsdHost = 'statsd.domain.org';
+	parsoidConfig.txstatsdPort = 8125;
+	*/
+
+	// Alternatively, define performanceTimer as follows:
+	/*
+	parsoidConfig.performanceTimer = {
+		timing: function(metricName, time) { }, // do-something-with-it
+		count: function(metricName, value) { }, // do-something-with-it
+	};
+	*/
+
+	// How often should we emit a heap sample? Time in ms.
+	// This setting is only relevant if you have enabled
+	// performance monitoring either via the default metrics
+	// OR by defining your own performanceTimer properties
+	//parsoidConfig.heapUsageSampleInterval = 5 * 60 * 1000;
+
+	// Allow override of port/interface:
+	//parsoidConfig.serverPort = 8000;
+	//parsoidConfig.serverInterface = '127.0.0.1';
+
+	// The URL of your LintBridge API endpoint
+	//parsoidConfig.linterAPI = 'http://lintbridge.wmflabs.org/add';
+
+	// Require SSL certificates to be valid (default true)
+	// Set to false when using self-signed SSL certificates
+	//parsoidConfig.strictSSL = false;
+
+	// Use a different server for CSS style modules.
+	// Set to true to use bits.wikimedia.org, or to a string with the URI.
+	// Leaving it undefined (the default) will use the same URI as the MW API,
+	// changing api.php for load.php.
+	//parsoidConfig.modulesLoadURI = true;
+
+	// Suppress some warnings from the Mediawiki API
+	// (defaults to suppressing warnings which the Parsoid team knows to
+	// be harmless)
+	//parsoidConfig.suppressMwApiWarnings = /annoying warning|other warning/;
+};
+
+***
+
+Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
+
+
+# Start the server
+cd .. (to parsoid dir)
+node api/server.js
+
+Note that you can't access the parsoid service via 192.168.56.58:8000 (at least by default), but you can use curl 127.0.0.1:8000 to verify it works
+
+Need to replace or add after # Start the server with an automated way of starting the server (upon reboot)
+https://www.mediawiki.org/wiki/Parsoid/Developer_Setup#Starting_the_Parsoid_service_automatically
+
+
+# Install Extension:UniversalLanguageSelector
+
+echo " " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "\$egExtensionLoaderConfig += array( " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "	'UniversalLanguageSelector' => array( " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/UniversalLanguageSelector.git', " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "		'branch' => 'REL1_25', " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "	), " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "	'VisualEditor' => array( " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "		'git' => 'https://gerrit.wikimedia.org/r/p/mediawiki/extensions/VisualEditor.git', " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "		'branch' => 'REL1_25', " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "	), " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "); " >> ~/sources/meza1/client_files/ExtensionSettings.php
+echo "" >> ~/sources/meza1/client_files/ExtensionSettings.php
+
+php /var/www/meza1/htdocs/wiki/extensions/ExtensionLoader/updateExtensions.php
+
+
+cd /usr/var/meza1/htdocs/wiki/extensions/VisualEditor
+git submodule update --init
+
+
+Note documentation for multi-language support configuration: https://www.mediawiki.org/wiki/Extension:UniversalLanguageSelector
+
+# Add to LocalSettings.php
+some command ****
+
+require_once "$IP/extensions/VisualEditor/VisualEditor.php";
+
+// Enable by default for everybody
+$wgDefaultUserOptions['visualeditor-enable'] = 1;
+
+// Don't allow users to disable it
+$wgHiddenPrefs[] = 'visualeditor-enable';
+
+// OPTIONAL: Enable VisualEditor's experimental code features
+#$wgDefaultUserOptions['visualeditor-enable-experimental'] = 1;
+
+// URL to the Parsoid instance
+// MUST NOT end in a slash due to Parsoid bug
+// Use port 8142 if you use the Debian package
+$wgVisualEditorParsoidURL = 'http://localhost:8000';
+
+// Interwiki prefix to pass to the Parsoid instance
+// Parsoid will be called as $url/$prefix/$pagename
+$wgVisualEditorParsoidPrefix = 'MezaWiki';
+
+Note: Other extensions which load plugins for VE (e.g. Math) should be loaded after VE for those plugins to work.
+
+
+
+

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -19,7 +19,9 @@ cd /etc
 git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
 cd parsoid
 echo "******* Installing parsoid *******"
-npm install -g # install globally
+#npm install -g # install globally
+#attempt to install globally was resulting in several errors
+npm install
 # npm install results in "npm WARN prefer global jshint@2.8.0 should be installed with -g"
 
 echo "******* Testing parsoid *******"
@@ -83,6 +85,7 @@ chkconfig --add /etc/init.d/parsoid
 echo "******* Starting parsoid server *******"
 #chkconfig parsoid on
 service parsoid start
+sleep 10  # Waits 10 seconds
 echo "******* Please test VE in your wiki *******"
 
 # Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -26,7 +26,7 @@ npm test #optional?
 # several warnings come out of npm test
 
 # Configure parsoid for wiki use
-# This part can be modified once localsettings.js is included in initial download of files
+# TODO This part can be modified once localsettings.js is included in initial download of files
 # TODO change client_files to master once merged
 # localsettings for parsoid
 echo "******* Downloading configuration files *******"
@@ -55,14 +55,28 @@ git submodule update --init
 # Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
 
 # Start the server
-echo "******* Starting parsoid server *******"
-node /etc/parsoid/api/server.js
-
-# Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)
-# but you can use curl 127.0.0.1:8000 in ssh to verify it works
+#echo "******* Starting parsoid server *******"
+#node /etc/parsoid/api/server.js
 
 # Need to replace or add an automated way of starting the server (upon reboot)
 # https://www.mediawiki.org/wiki/Parsoid/Developer_Setup#Starting_the_Parsoid_service_automatically
+# http://www.tldp.org/HOWTO/HighQuality-Apps-HOWTO/boot.html
+# https://github.com/narath/brigopedia#setup-visualeditor-extension
+# Create service script
+echo "******* Creaing parsoid service *******"
+cd ~/sources/meza1/client_files
+# TODO This part can be modified once localsettings.js is included in initial download of files
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/initd_parsoid.sh
+cp initd_parsoid.sh /etc/init.d/parsoid
+chmod +x /etc/init.d/parsoid
+
+# Start parsoid service
+echo "******* Starting parsoid server *******"
+chkconfig httpd on
+service httpd status
+
+# Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)
+# but you can use curl 127.0.0.1:8000 in ssh to verify it works
 
 # Note documentation for multi-language support configuration: https://www.mediawiki.org/wiki/Extension:UniversalLanguageSelector
 

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -1,5 +1,5 @@
 
-echo "*** Downloading node.js ***"
+echo "******* Downloading node.js *******"
 cd ~/sources
 
 # Download, compile, and install node
@@ -7,21 +7,21 @@ wget https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz
 tar zxvf node-v0.12.5.tar.gz
 cd node-v0.12.5
 ./configure
-echo "*** Compiling node.js ***"
+echo "******* Compiling node.js *******"
 make
-echo "*** Installing node.js ***"
+echo "******* Installing node.js *******"
 make install
 
 # Download and install parsoid\
-echo "*** Downloading parsoid ***"
-cd /etc/mediawiki
+echo "******* Downloading parsoid *******"
+cd /etc
 git clone https://gerrit.wikimedia.org/r/p/mediawiki/services/parsoid
 cd parsoid
-echo "*** Installing parsoid ***"
-npm install
+echo "******* Installing parsoid *******"
+npm install -g # install globally
 # npm install results in "npm WARN prefer global jshint@2.8.0 should be installed with -g"
 
-echo "*** Testing parsoid ***"
+echo "******* Testing parsoid *******"
 npm test #optional?
 # several warnings come out of npm test
 
@@ -29,10 +29,10 @@ npm test #optional?
 # This part can be modified once localsettings.js is included in initial download of files
 # TODO change client_files to master once merged
 # localsettings for parsoid
-echo "*** Downloading configuration files ***"
+echo "******* Downloading configuration files *******"
 cd ~/sources/meza1/client_files
 wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/localsettings.js
-cp localsettings.js /etc/mediawiki/parsoid/api/localsettings.js
+cp localsettings.js /etc/parsoid/api/localsettings.js
 # Add VE and UniversalLanguageSelector to ExtensionSettings
 wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/installVE/client_files/ExtensionSettingsVE.php
 cp ExtensionSettingsVE.php /var/www/meza1/htdocs/wiki/ExtensionSettingsVE.php
@@ -43,11 +43,11 @@ cp LocalSettingsVE.php /var/www/meza1/htdocs/wiki/LocalSettingsVE.php
 cat /var/www/meza1/htdocs/wiki/LocalSettingsVE.php >> /var/www/meza1/htdocs/wiki/LocalSettings.php
 
 # Run updateExtensions to install UniversalLanguageSelector and VisualEditor
-echo "*** Installing extensions ***"
+echo "******* Installing extensions *******"
 php /var/www/meza1/htdocs/wiki/extensions/ExtensionLoader/updateExtensions.php
 
-echo "*** Installing VE ***"
-cd /usr/var/meza1/htdocs/wiki/extensions/VisualEditor
+echo "******* Installing VE *******"
+cd /var/www/meza1/htdocs/wiki/extensions/VisualEditor
 # Will this git command work with the way ExtensionLoader installs the extension?
 git submodule update --init
 
@@ -55,8 +55,8 @@ git submodule update --init
 # Read https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis
 
 # Start the server
-echo "*** Starting parsoid server ***"
-node ~/sources/parsoid/api/server.js
+echo "******* Starting parsoid server *******"
+node /etc/parsoid/api/server.js
 
 # Note that you can't access the parsoid service via 192.168.56.58:8000 from host (at least by default)
 # but you can use curl 127.0.0.1:8000 in ssh to verify it works

--- a/client_files/initd_parsoid.sh
+++ b/client_files/initd_parsoid.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+#
+# chkconfig: 35 99 99
+# description: Node.js /etc/parsoid/api/server.js
+#
+
+. /etc/rc.d/init.d/functions
+
+USER="parsoid"
+
+DAEMON="/usr/local/bin/node"
+ROOT_DIR="/etc/parsoid/api"
+
+SERVER="$ROOT_DIR/server.js"
+LOG_FILE="$ROOT_DIR/server.js.log"
+
+LOCK_FILE="/var/lock/subsys/node-server"
+
+do_start()
+{
+        if [ ! -f "$LOCK_FILE" ] ; then
+                echo -n $"Starting $SERVER: "
+                runuser -l "$USER" -c "$DAEMON $SERVER >> $LOG_FILE &" && echo_success || echo_failure
+                RETVAL=$?
+                echo
+                [ $RETVAL -eq 0 ] && touch $LOCK_FILE
+        else
+                echo "$SERVER is locked."
+                RETVAL=1
+        fi
+}
+do_stop()
+{
+        echo -n $"Stopping $SERVER: "
+        pid=`ps -aefw | grep "$DAEMON $SERVER" | grep -v " grep " | awk '{print $2}'`
+        kill -9 $pid > /dev/null 2>&1 && echo_success || echo_failure
+        RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && rm -f $LOCK_FILE
+}
+
+case "$1" in
+        start)
+                do_start
+                ;;
+        stop)
+                do_stop
+                ;;
+        restart)
+                do_stop
+                do_start
+                ;;
+        *)
+                echo "Usage: $0 {start|stop|restart}"
+                RETVAL=1
+esac
+
+exit $RETVAL

--- a/client_files/initd_parsoid.sh
+++ b/client_files/initd_parsoid.sh
@@ -24,7 +24,8 @@ do_start()
 
                 # Use "nohup" to prevent hang-up. Thanks to:
                 # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
-                runuser -l "nohup $USER" -c "$DAEMON $SERVER > $LOG_FILE &" && echo_success || echo_failure
+                runuser -l "$USER" -c "nohup $DAEMON $SERVER > $LOG_FILE &" && echo_success || echo_failure
+
                 RETVAL=$?
                 echo
                 [ $RETVAL -eq 0 ] && touch $LOCK_FILE

--- a/client_files/initd_parsoid.sh
+++ b/client_files/initd_parsoid.sh
@@ -22,9 +22,6 @@ get_parsoid_process_id()
 {
 	echo `ps -aefw | grep "$DAEMON $SERVER" | grep -v " grep " | awk '{print $2}'`
 }
-
-
-
 parsoid_start_echo_success()
 {
 	# Wait 10 seconds since paroid takes some time to start and we don't have a
@@ -35,14 +32,21 @@ parsoid_start_echo_success()
 do_start()
 {
     pid=$(get_parsoid_process_id)
-    echo "Current parsoid process ID: $pid (end pid)"
 
-    echo -n $"Starting $SERVER: "
+    # if no parsoid process exists already
+	if [ -z "$pid" ]; then
 
-    # Use "nohup" to prevent hang-up. Thanks to:
-    # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
-    runuser -l "$USER" -c "nohup $DAEMON $SERVER >> $LOG_FILE &" && parsoid_start_echo_success || echo_failure
-    RETVAL=$?
+	    echo -n $"Starting $SERVER: "
+
+	    # Use "nohup" to prevent hang-up. Thanks to:
+	    # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
+	    runuser -l "$USER" -c "nohup $DAEMON $SERVER >> $LOG_FILE 2>&1 &" && parsoid_start_echo_success || echo_failure
+	    RETVAL=$?
+
+	else
+	    echo "Parsoid already running with process ID = $pid"
+	    RETVAL=1
+	fi
 }
 do_stop()
 {
@@ -50,6 +54,7 @@ do_stop()
     # pid=`ps -aefw | grep "$DAEMON $SERVER" | grep -v " grep " | awk '{print $2}'`
     pid=$(get_parsoid_process_id)
     kill -9 $pid > /dev/null 2>&1 && echo_success || echo_failure
+    echo ""
     RETVAL=$?
 }
 

--- a/client_files/initd_parsoid.sh
+++ b/client_files/initd_parsoid.sh
@@ -24,7 +24,7 @@ do_start()
 
                 # Use "nohup" to prevent hang-up. Thanks to:
                 # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
-                runuser -l "$USER" -c "nohup $DAEMON $SERVER > $LOG_FILE &" && echo_success || echo_failure
+                runuser -l "$USER" -c "nohup $DAEMON $SERVER >> $LOG_FILE &" && echo_success || echo_failure
 
                 RETVAL=$?
                 echo

--- a/client_files/initd_parsoid.sh
+++ b/client_files/initd_parsoid.sh
@@ -21,7 +21,10 @@ do_start()
 {
         if [ ! -f "$LOCK_FILE" ] ; then
                 echo -n $"Starting $SERVER: "
-                runuser -l "$USER" -c "$DAEMON $SERVER >> $LOG_FILE &" && echo_success || echo_failure
+
+                # Use "nohup" to prevent hang-up. Thanks to:
+                # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
+                runuser -l "nohup $USER" -c "$DAEMON $SERVER > $LOG_FILE &" && echo_success || echo_failure
                 RETVAL=$?
                 echo
                 [ $RETVAL -eq 0 ] && touch $LOCK_FILE

--- a/client_files/initd_parsoid.sh
+++ b/client_files/initd_parsoid.sh
@@ -5,6 +5,7 @@
 # description: Node.js /etc/parsoid/api/server.js
 #
 
+# provides echo_success and echo_failure functions (amongst others)
 . /etc/rc.d/init.d/functions
 
 USER="parsoid"
@@ -17,31 +18,39 @@ LOG_FILE="$ROOT_DIR/server.js.log"
 
 LOCK_FILE="/var/lock/subsys/node-server"
 
+get_parsoid_process_id()
+{
+	echo `ps -aefw | grep "$DAEMON $SERVER" | grep -v " grep " | awk '{print $2}'`
+}
+
+
+
+parsoid_start_echo_success()
+{
+	# Wait 10 seconds since paroid takes some time to start and we don't have a
+	# good method to be told when it's up
+	sleep 10
+	echo_success # normal echo_success function
+}
 do_start()
 {
-        if [ ! -f "$LOCK_FILE" ] ; then
-                echo -n $"Starting $SERVER: "
+    pid=$(get_parsoid_process_id)
+    echo "Current parsoid process ID: $pid (end pid)"
 
-                # Use "nohup" to prevent hang-up. Thanks to:
-                # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
-                runuser -l "$USER" -c "nohup $DAEMON $SERVER >> $LOG_FILE &" && echo_success || echo_failure
+    echo -n $"Starting $SERVER: "
 
-                RETVAL=$?
-                echo
-                [ $RETVAL -eq 0 ] && touch $LOCK_FILE
-        else
-                echo "$SERVER is locked."
-                RETVAL=1
-        fi
+    # Use "nohup" to prevent hang-up. Thanks to:
+    # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
+    runuser -l "$USER" -c "nohup $DAEMON $SERVER >> $LOG_FILE &" && parsoid_start_echo_success || echo_failure
+    RETVAL=$?
 }
 do_stop()
 {
-        echo -n $"Stopping $SERVER: "
-        pid=`ps -aefw | grep "$DAEMON $SERVER" | grep -v " grep " | awk '{print $2}'`
-        kill -9 $pid > /dev/null 2>&1 && echo_success || echo_failure
-        RETVAL=$?
-        echo
-        [ $RETVAL -eq 0 ] && rm -f $LOCK_FILE
+    echo -n $"Stopping $SERVER: "
+    # pid=`ps -aefw | grep "$DAEMON $SERVER" | grep -v " grep " | awk '{print $2}'`
+    pid=$(get_parsoid_process_id)
+    kill -9 $pid > /dev/null 2>&1 && echo_success || echo_failure
+    RETVAL=$?
 }
 
 case "$1" in

--- a/client_files/initd_parsoid.sh
+++ b/client_files/initd_parsoid.sh
@@ -41,8 +41,8 @@ do_start()
 	    # Use "nohup" to prevent hang-up. Thanks to:
 	    # http://stackoverflow.com/questions/5818202/how-to-run-node-js-app-forever-when-console-is-closed
 	    runuser -l "$USER" -c "nohup $DAEMON $SERVER >> $LOG_FILE 2>&1 &" && parsoid_start_echo_success || echo_failure
+	    echo "" # newline after success/failure
 	    RETVAL=$?
-
 	else
 	    echo "Parsoid already running with process ID = $pid"
 	    RETVAL=1
@@ -54,7 +54,7 @@ do_stop()
     # pid=`ps -aefw | grep "$DAEMON $SERVER" | grep -v " grep " | awk '{print $2}'`
     pid=$(get_parsoid_process_id)
     kill -9 $pid > /dev/null 2>&1 && echo_success || echo_failure
-    echo ""
+    echo "" # newline after success/failure
     RETVAL=$?
 }
 

--- a/client_files/localsettings.js
+++ b/client_files/localsettings.js
@@ -1,0 +1,92 @@
+'use strict';
+
+exports.setup = function(parsoidConfig) {
+	// Set your own user-agent string
+	// Otherwise, defaults to "Parsoid/<current-version-defined-in-package.json>"
+	//parsoidConfig.userAgent = "My-User-Agent-String";
+
+	// The URL of your MediaWiki API endpoint.
+	parsoidConfig.setMwApi( 'wiki', { uri: 'http://127.0.0.1/wiki/api.php' });
+	// To specify a proxy (or proxy headers) specific to this prefix (which
+	// overrides defaultAPIProxyURI) use:
+	/*
+	parsoidConfig.setMwApi('localhost', {
+		uri: 'http://localhost/w/api.php',
+		// set `proxy` to `null` to override and force no proxying.
+		proxy: {
+			uri: 'http://my.proxy:1234/',
+			headers: { 'X-Forwarded-Proto': 'https' } // headers are optional
+		}
+	});
+	*/
+
+	// We pre-define wikipedias as 'enwiki', 'dewiki' etc. Similarly
+	// for other projects: 'enwiktionary', 'enwikiquote', 'enwikibooks',
+	// 'enwikivoyage' etc. (default true)
+	parsoidConfig.loadWMF = false;
+
+	// A default proxy to connect to the API endpoints.
+	// Default: undefined (no proxying).
+	// Overridden by per-wiki proxy config in setMwApi.
+	//parsoidConfig.defaultAPIProxyURI = 'http://proxy.example.org:8080';
+
+	// Enable debug mode (prints extra debugging messages)
+	//parsoidConfig.debug = true;
+
+	// Use the PHP preprocessor to expand templates via the MW API (default true)
+	//parsoidConfig.usePHPPreProcessor = false;
+
+	// Use selective serialization (default false)
+	parsoidConfig.useSelser = true;
+
+	// Allow cross-domain requests to the API (default '*')
+	// Sets Access-Control-Allow-Origin header
+	// disable:
+	//parsoidConfig.allowCORS = false;
+	// restrict:
+	//parsoidConfig.allowCORS = 'some.domain.org';
+
+	// Set to true for using the default performance metrics reporting to statsd
+	// If true, provide the statsd host/port values
+	/*
+	parsoidConfig.useDefaultPerformanceTimer = true;
+	parsoidConfig.txstatsdHost = 'statsd.domain.org';
+	parsoidConfig.txstatsdPort = 8125;
+	*/
+
+	// Alternatively, define performanceTimer as follows:
+	/*
+	parsoidConfig.performanceTimer = {
+		timing: function(metricName, time) { }, // do-something-with-it
+		count: function(metricName, value) { }, // do-something-with-it
+	};
+	*/
+
+	// How often should we emit a heap sample? Time in ms.
+	// This setting is only relevant if you have enabled
+	// performance monitoring either via the default metrics
+	// OR by defining your own performanceTimer properties
+	//parsoidConfig.heapUsageSampleInterval = 5 * 60 * 1000;
+
+	// Allow override of port/interface:
+	//parsoidConfig.serverPort = 8000;
+	parsoidConfig.serverInterface = '127.0.0.1';
+
+	// The URL of your LintBridge API endpoint
+	//parsoidConfig.linterAPI = 'http://lintbridge.wmflabs.org/add';
+
+	// Require SSL certificates to be valid (default true)
+	// Set to false when using self-signed SSL certificates
+	//parsoidConfig.strictSSL = false;
+
+	// Use a different server for CSS style modules.
+	// Set to true to use bits.wikimedia.org, or to a string with the URI.
+	// Leaving it undefined (the default) will use the same URI as the MW API,
+	// changing api.php for load.php.
+	//parsoidConfig.modulesLoadURI = true;
+
+	// Suppress some warnings from the Mediawiki API
+	// (defaults to suppressing warnings which the Parsoid team knows to
+	// be harmless)
+	//parsoidConfig.suppressMwApiWarnings = /annoying warning|other warning/;
+};


### PR DESCRIPTION
This adds a new script VE.sh, several configuration files, and an init.d script to start the parsoid service on boot. I have tested this from the point of successful completion of extensions.sh. Note that VE.sh has several places where it uses wget to pull files that should already be available from the initial tarball. I'm not sure if we should change this now or wait until later.

TODO: Please change all instances of "installVE" to "master" in directories. This should be on lines 37, 40, 44, and 79.

Note that we will likely need to make some modifications to account for a private wiki per [this page](https://www.mediawiki.org/wiki/Extension:VisualEditor#Linking_with_Parsoid_in_private_wikis)

References:
* [init.d boot script](http://www.tldp.org/HOWTO/HighQuality-Apps-HOWTO/boot.html)
* [another wiki scripted install for VE](https://github.com/narath/brigopedia#setup-visualeditor-extension)

Note that this installs parsoid locally, not globally. When I tried to install it globally, it did not work. Here is one of the errors I saw:
```
gyp WARN EACCES user "root" does not have permission to access the dev dir "/root/.node-gyp/0.12.5"
gyp WARN EACCES attempting to reinstall using temporary dev dir "/usr/local/lib/node_modules/parsoid/node_modules/html5/node_modules/jsdom/node_modules/contextify/.node-gyp"
```