### PR TITLE
Run "exec bash" to make PHP command available immediately

### DIFF
--- a/client_files/php.sh
+++ b/client_files/php.sh
@@ -89,10 +89,10 @@ make install
 
 
 #
-# Add PHP to path
+# Add PHP to path and refresh bash
 #
 echo "export PATH=/usr/local/php/bin:\$PATH" > /etc/profile.d/php.sh
-
+exec bash
 
 #
 # Initiate php.ini


### PR DESCRIPTION
PHP in PATH required to run mediawiki-quick.sh