### PR TITLE
Emergency fix: bump apache from 2.4.12 to 2.4.16

### DIFF
--- a/client_files/apache.sh
+++ b/client_files/apache.sh
@@ -13,7 +13,7 @@ cd ~/sources
 # [1] http://www.us.apache.org/dist//httpd/
 # [2] http://www.us.apache.org/dist//apr
 #
-wget http://www.us.apache.org/dist//httpd/httpd-2.4.12.tar.gz
+wget http://www.us.apache.org/dist//httpd/httpd-2.4.16.tar.gz
 wget http://www.us.apache.org/dist//apr/apr-1.5.2.tar.gz
 wget http://www.us.apache.org/dist//apr/apr-util-1.5.4.tar.gz
 

--- a/client_files/apache.sh
+++ b/client_files/apache.sh
@@ -21,12 +21,12 @@ wget http://www.us.apache.org/dist//apr/apr-util-1.5.4.tar.gz
 #
 # Unpack and build Apache from source
 #
-tar -zxvf httpd-2.4.12.tar.gz
+tar -zxvf httpd-2.4.16.tar.gz
 tar -zxvf apr-1.5.2.tar.gz
 tar -zxvf apr-util-1.5.4.tar.gz
-cp -r apr-1.5.2 httpd-2.4.12/srclib/apr
-cp -r apr-util-1.5.4 httpd-2.4.12/srclib/apr-util
-cd httpd-2.4.12
+cp -r apr-1.5.2 httpd-2.4.16/srclib/apr
+cp -r apr-util-1.5.4 httpd-2.4.16/srclib/apr-util
+cd httpd-2.4.16
 ./configure --enable-ssl --enable-so --with-included-apr --with-mpm=event
 make
 make install

--- a/client_files/apache.sh
+++ b/client_files/apache.sh
@@ -13,7 +13,8 @@ cd ~/sources
 # [1] http://www.us.apache.org/dist//httpd/
 # [2] http://www.us.apache.org/dist//apr
 #
-wget http://www.us.apache.org/dist//httpd/httpd-2.4.16.tar.gz
+httpdversion="2.4.16"
+wget "http://www.us.apache.org/dist//httpd/httpd-$httpdversion.tar.gz"
 wget http://www.us.apache.org/dist//apr/apr-1.5.2.tar.gz
 wget http://www.us.apache.org/dist//apr/apr-util-1.5.4.tar.gz
 
@@ -21,12 +22,12 @@ wget http://www.us.apache.org/dist//apr/apr-util-1.5.4.tar.gz
 #
 # Unpack and build Apache from source
 #
-tar -zxvf httpd-2.4.16.tar.gz
+tar -zxvf "httpd-$httpdversion.tar.gz"
 tar -zxvf apr-1.5.2.tar.gz
 tar -zxvf apr-util-1.5.4.tar.gz
-cp -r apr-1.5.2 httpd-2.4.16/srclib/apr
-cp -r apr-util-1.5.4 httpd-2.4.16/srclib/apr-util
-cd httpd-2.4.16
+cp -r apr-1.5.2 "httpd-$httpdversion/srclib/apr"
+cp -r apr-util-1.5.4 "httpd-$httpdversion/srclib/apr-util"
+cd "httpd-$httpdversion"
 ./configure --enable-ssl --enable-so --with-included-apr --with-mpm=event
 make
 make install


### PR DESCRIPTION
Currently master (and all other active branches) are downloading Apache httpd 2.4.12, which does not exist at the location attempted to be downloaded from. We need to find a more robust way of downloading. As an emergency fix, bump httpd to 2.4.16