### PR TITLE
Parsoid's setMwApi needs correct URI to use VE with images

### DIFF
--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -119,14 +119,14 @@ done
 
 while [ "$mw_api_protocol" != "http" ] && [ "$mw_api_protocol" != "https" ]
 do
-	echo -e "\nType \"http\" or \"https\" for MW API and press [ENTER]: "
-	read mw_api_protocol
+echo -e "\nType http or https for MW API and press [ENTER]: "
+read mw_api_protocol
 done
 
 while [ -z "$mw_api_domain" ]
 do
-	echo -e "\nType domain or IP address of your wiki and press [ENTER]: "
-	read mw_api_domain
+echo -e "\nType domain or IP address of your wiki and press [ENTER]: "
+read mw_api_domain
 done
 
 

--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -57,6 +57,14 @@ if [ ! -z "$8" ]; then
     git_branch="$8"
 fi
 
+if [ ! -z "$9" ]; then
+    mw_api_protocol="$9"
+fi
+
+if [ ! -z "$10" ]; then
+    mw_api_domain="$10"
+fi
+
 
 # Force user to pick an architecture: 32 or 64 bit
 while [ "$architecture" != "32" ] && [ "$architecture" != "64" ]
@@ -109,6 +117,19 @@ echo -e "\nEnter git branch of Meza1 you want to use (generally this is \"master
 read git_branch
 done
 
+while [ "$mw_api_protocol" != "http" ] && [ "$mw_api_protocol" != "https" ]
+do
+	echo -e "\nType \"http\" or \"https\" for MW API and press [ENTER]: "
+	read mw_api_protocol
+done
+
+while [ -z "$mw_api_domain" ]
+do
+	echo -e "\nType domain or IP address of your wiki and press [ENTER]: "
+	read mw_api_domain
+done
+
+
 
 # Check if git installed, and install it if required
 if ! hash git 2>/dev/null; then
@@ -159,7 +180,7 @@ bash mysql.sh "$mysql_root_pass" || exit 1
 bash mediawiki-quick.sh "$mysql_root_pass" "$wiki_db_name" "$wiki_name" "$wiki_admin_name" "$wiki_admin_pass" || exit 1
 
 bash extensions.sh || exit 1
-bash VE.sh || exit 1
+bash VE.sh "$mw_api_protocol" "$mw_api_domain" || exit 1
 
 
 # Display Most Plusquamperfekt Wiki Pigeon of Victory

--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -61,8 +61,8 @@ if [ ! -z "$9" ]; then
     mw_api_protocol="$9"
 fi
 
-if [ ! -z "$10" ]; then
-    mw_api_domain="$10"
+if [ ! -z "${10}" ]; then
+    mw_api_domain="${10}"
 fi
 
 

--- a/client_files/localsettings.js
+++ b/client_files/localsettings.js
@@ -6,7 +6,7 @@ exports.setup = function(parsoidConfig) {
 	//parsoidConfig.userAgent = "My-User-Agent-String";
 
 	// The URL of your MediaWiki API endpoint.
-	parsoidConfig.setMwApi( 'wiki', { uri: 'http://127.0.0.1/wiki/api.php' });
+	parsoidConfig.setMwApi( 'wiki', { uri: 'http://192.168.56.56/wiki/api.php' });
 	// To specify a proxy (or proxy headers) specific to this prefix (which
 	// overrides defaultAPIProxyURI) use:
 	/*

--- a/client_files/localsettings.js
+++ b/client_files/localsettings.js
@@ -6,7 +6,10 @@ exports.setup = function(parsoidConfig) {
 	//parsoidConfig.userAgent = "My-User-Agent-String";
 
 	// The URL of your MediaWiki API endpoint.
-	parsoidConfig.setMwApi( 'wiki', { uri: 'http://192.168.56.56/wiki/api.php' });
+	// uri like:
+	//     http://192.168.56.56/wiki/api.php
+	//     http://enterprisemediawiki.org/wiki/api.php
+	parsoidConfig.setMwApi( 'wiki', { uri: 'INSERTED_BY_VE_SCRIPT' });
 	// To specify a proxy (or proxy headers) specific to this prefix (which
 	// overrides defaultAPIProxyURI) use:
 	/*


### PR DESCRIPTION
The modified URI is the default VirtualBox IP address we're using.
This URI must be the endpoint URI that the user navigates to,
because when Parsoid serves up URIs for images (and probably other
resources) it uses this URI. So otherwise it goes looking for
images at http://127.0.0.1/<whatever>, which is on the user's
computer...doesn't work.