### PR TITLE
Separate build-index script for Elastic Search

### DIFF
--- a/client_files/ElasticSearch.sh
+++ b/client_files/ElasticSearch.sh
@@ -140,7 +140,7 @@ sleep 20  # Waits 10 seconds
 # Ref: https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FCirrusSearch.git/REL1_25/README
 #
 echo "******* Running elastic-build-index.sh *******"
-bash elastic-build-index.sh
+bash ~/sources/meza1/client_files/elastic-build-index.sh
 
 # Add "$wgSearchType = 'CirrusSearch';" to LocalSettings.php to funnel queries to ElasticSearch
 cd /var/www/meza1/htdocs/wiki

--- a/client_files/ElasticSearch.sh
+++ b/client_files/ElasticSearch.sh
@@ -139,27 +139,11 @@ sleep 20  # Waits 10 seconds
 #
 # Ref: https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FCirrusSearch.git/REL1_25/README
 #
-echo "******* Generating elasticsearch index *******"
+echo "******* Running elastic-build-index.sh *******"
+bash elastic-build-index.sh
 
-# Add "$wgDisableSearchUpdate = true;" to LocalSettings.php
-# Ref: http://stackoverflow.com/questions/525592/find-and-replace-inside-a-text-file-from-a-bash-command
-cd /var/www/meza1/htdocs/wiki
-sed -i -e 's/\/\/ES-CONFIG-ANCHOR/$wgDisableSearchUpdate = true;/g' LocalSettings.php
-
-# Run script to generate elasticsearch index
-php /var/www/meza1/htdocs/wiki/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php
- 
-# Remove $wgDisableSearchUpdate = true from LocalSettings.php (updates should start heading to elasticsearch)
-sed -i -e 's/$wgDisableSearchUpdate = true;/\/\/ES-CONFIG-ANCHOR/g' LocalSettings.php
-
-# Bootstrap the search index
-#
-# Note that this can take some time
-# For large wikis read "Bootstrapping large wikis" in https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FCirrusSearch.git/REL1_25/README
-php /var/www/meza1/htdocs/wiki/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipLinks --indexOnSkip
-php /var/www/meza1/htdocs/wiki/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipParse
- 
 # Add "$wgSearchType = 'CirrusSearch';" to LocalSettings.php to funnel queries to ElasticSearch
+cd /var/www/meza1/htdocs/wiki
 sed -i -e 's/\/\/ES-CONFIG-ANCHOR/$wgSearchType = "CirrusSearch";/g' LocalSettings.php
 
 echo "******* Complete! *******"

--- a/client_files/elastic-build-index.sh
+++ b/client_files/elastic-build-index.sh
@@ -1,0 +1,25 @@
+bash printTitle.sh "Begin $0"
+
+echo "******* Generating elasticsearch index *******"
+
+# Add "$wgDisableSearchUpdate = true;" to LocalSettings.php
+cd /var/www/meza1/htdocs/wiki
+echo '$wgDisableSearchUpdate = true;' >> ./LocalSettings.php
+
+# @todo: do we need to remove $wgSearchType = 'CirrusSearch' if it is present?
+# it appears to work without doing that
+
+# Run script to generate elasticsearch index
+php /var/www/meza1/htdocs/wiki/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php
+
+# Remove $wgDisableSearchUpdate = true from LocalSettings.php (updates should start heading to elasticsearch)
+sed -i -e 's/$wgDisableSearchUpdate = true;//g' LocalSettings.php
+
+# Bootstrap the search index
+#
+# Note that this can take some time
+# For large wikis read "Bootstrapping large wikis" in https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FCirrusSearch.git/REL1_25/README
+php /var/www/meza1/htdocs/wiki/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipLinks --indexOnSkip
+php /var/www/meza1/htdocs/wiki/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipParse
+
+echo "******* Elastic Search build index complete! *******"

--- a/client_files/import-wiki.sh
+++ b/client_files/import-wiki.sh
@@ -114,4 +114,8 @@ cd "$wiki_root/maintenance"
 php runJobs.php --quick
 
 
+echo "Building Elastic Search index"
+bash ~/sources/meza1/client_files/elastic-build-index.sh
+
+
 echo -e "\nYour wiki has been imported!\n"


### PR DESCRIPTION
Previously the "build index" steps were in the Elastic Search install script. Since importing a wiki may come after these steps, building of the index needs to be a separate task. Also, at times rebuilding the index may be required.