### PR TITLE
Fix issue with certain yum repos not being available on RedHat

### DIFF
--- a/client_files/ElasticSearch.sh
+++ b/client_files/ElasticSearch.sh
@@ -19,6 +19,10 @@ bash printTitle.sh "Begin $0"
 # https://wikitech.wikimedia.org/wiki/Search
 #
 
+if [[ $PATH != *"/usr/local/bin"* ]]; then
+  PATH="/usr/local/bin:$PATH"
+fi
+
 #
 # Install JAVA
 # 

--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -15,6 +15,16 @@ fi
 
 echo -e "\nWelcome to Meza1 v0.2.0\n"
 
+#
+# Set architecture to 32 or 64 (bit)
+#
+if [ $(uname -m | grep -c 64) -eq 1 ]; then
+architecture=64
+else
+architecture=32
+fi
+
+
 # if the script was called in the form:
 # bash install <architecture> \
 #              <phpversion> \
@@ -28,52 +38,41 @@ echo -e "\nWelcome to Meza1 v0.2.0\n"
 # These are out of hand. Change them to GNU-style long-options, see:
 # http://mywiki.wooledge.org/BashFAQ/035
 if [ ! -z "$1" ]; then
-    architecture="$1"
+    phpversion="$1"
 fi
 
 if [ ! -z "$2" ]; then
-    phpversion="$2"
+    mysql_root_pass="$2"
 fi
 
 if [ ! -z "$3" ]; then
-    mysql_root_pass="$3"
+    wiki_db_name="$3"
 fi
 
 if [ ! -z "$4" ]; then
-    wiki_db_name="$4"
+    wiki_name="$4"
 fi
 
 if [ ! -z "$5" ]; then
-    wiki_name="$5"
+    wiki_admin_name="$5"
 fi
 
 if [ ! -z "$6" ]; then
-    wiki_admin_name="$6"
+    wiki_admin_pass="$6"
 fi
 
 if [ ! -z "$7" ]; then
-    wiki_admin_pass="$7"
+    git_branch="$7"
 fi
 
 if [ ! -z "$8" ]; then
-    git_branch="$8"
+    mw_api_protocol="$8"
 fi
 
 if [ ! -z "$9" ]; then
-    mw_api_protocol="$9"
+    mw_api_domain="$9"
 fi
 
-if [ ! -z "${10}" ]; then
-    mw_api_domain="${10}"
-fi
-
-
-# Force user to pick an architecture: 32 or 64 bit
-while [ "$architecture" != "32" ] && [ "$architecture" != "64" ]
-do
-echo -e "\nWhich architecture are you using? Type 32 or 64 and press [ENTER]: "
-read architecture
-done
 
 # Prompt user for PHP version
 while [ -z "$phpversion" ]

--- a/client_files/yums.sh
+++ b/client_files/yums.sh
@@ -40,7 +40,7 @@ yum -y update
 #
 if [ -f /etc/centos-release ]; then
 	# do centos-specific stuff
-else {
+else
 	# do redhat-specific stuff
 	# thanks to https://bluehatrecord.wordpress.com for teaching me this
 	# https://bluehatrecord.wordpress.com/2014/10/13/installing-r-on-red-hat-enterprise-linux-6-5/
@@ -49,7 +49,7 @@ else {
 	# libc-client-devel, libicu-devel, t1lib-devel, aspell-devel, libvpx-devel
 	# and libtidy-devel 
 	subscription-manager repos --enable=rhel-6-server-optional-rpms
-}
+fi
 
 
 #

--- a/client_files/yums.sh
+++ b/client_files/yums.sh
@@ -7,21 +7,20 @@ bash printTitle.sh "Begin $0"
 
 cd ~/sources
 
-# if the script was called in the form:
-# bash yums.sh 32
-# then set architecture to 32 (meaning no user interaction required)
-if [ ! -z "$1" ]; then
-    architecture="$1"
+#
+# Set architecture to 32 or 64 (bit)
+#
+if [ ! -z "$architecture" ]; then
+    
+	# Set architecture to 32 or 64 (bit)
+	if [ $(uname -m | grep -c 64) -eq 1 ]; then
+	architecture=64
+	else
+	architecture=32
+	fi
+
 fi
 
-#
-# Force user to pick an architecture: 32 or 64 bit
-#
-while [ "$architecture" != "32" ] && [ "$architecture" != "64" ]
-do
-echo -e "\n\n\n\nWhich architecture are you using? Type 32 or 64 and press [ENTER]: "
-read architecture
-done
 
 if [ "$architecture" = "32" ]; then
     echo "Downloading RPM for 32-bit"
@@ -39,6 +38,23 @@ fi
 # Update everything managed by yum
 #
 yum -y update
+
+
+#
+# Do any RedHat or CentOS specific items
+#
+if [ -f /etc/centos-release ]; then
+	# do centos-specific stuff
+else {
+	# do redhat-specific stuff
+	# thanks to https://bluehatrecord.wordpress.com for teaching me this
+	# https://bluehatrecord.wordpress.com/2014/10/13/installing-r-on-red-hat-enterprise-linux-6-5/
+
+	# Enable "optional RPMs" repo to be able to get: libc-client-devel.i686,
+	# libc-client-devel, libicu-devel, t1lib-devel, aspell-devel, libvpx-devel
+	# and libtidy-devel 
+	subscription-manager repos --enable=rhel-6-server-optional-rpms
+}
 
 
 #
@@ -61,7 +77,7 @@ rpm -i rpmforge-release-0.5.3-1.el6.rf.*.rpm
 # safe than sorry--attempt to install them now anyway.
 #
 yum install -y \
-    zlib-dev \
+    zlib-devel \
     sqlite-devel \
     bzip2-devel \
     xz-libs \
@@ -88,7 +104,8 @@ yum install -y \
     freetype-devel \
     readline-devel \
     libtidy-devel \
-    libmcrypt-devel
+    libmcrypt-devel \
+    pam-devel
 
 
 #

--- a/client_files/yums.sh
+++ b/client_files/yums.sh
@@ -40,6 +40,7 @@ yum -y update
 #
 if [ -f /etc/centos-release ]; then
 	# do centos-specific stuff
+    echo "No special actions for CentOS" # need to have something in this block or error occurs
 else
 	# do redhat-specific stuff
 	# thanks to https://bluehatrecord.wordpress.com for teaching me this
@@ -48,6 +49,7 @@ else
 	# Enable "optional RPMs" repo to be able to get: libc-client-devel.i686,
 	# libc-client-devel, libicu-devel, t1lib-devel, aspell-devel, libvpx-devel
 	# and libtidy-devel 
+    echo "Enable \"Optional RPMs\" repo for RedHat"
 	subscription-manager repos --enable=rhel-6-server-optional-rpms
 fi
 

--- a/client_files/yums.sh
+++ b/client_files/yums.sh
@@ -10,15 +10,10 @@ cd ~/sources
 #
 # Set architecture to 32 or 64 (bit)
 #
-if [ ! -z "$architecture" ]; then
-    
-	# Set architecture to 32 or 64 (bit)
-	if [ $(uname -m | grep -c 64) -eq 1 ]; then
-	architecture=64
-	else
-	architecture=32
-	fi
-
+if [ $(uname -m | grep -c 64) -eq 1 ]; then
+architecture=64
+else
+architecture=32
 fi
 
 


### PR DESCRIPTION
RedHat has different repositories than CentOS, we've learned. In order to get access to the following packages the "rhel-6-server-optional-rpms" repository must be enabled.

* libc-client-devel.i686
* libc-client-devel
* libicu-devel
* t1lib-devel
* aspell-devel
* libvpx-devel
* libtidy-devel 

Additionally, architecture (32 vs 64 bit) is now autodetected rather than requested from the user. This was done in conjunction with autodetecting RedHat vs CentOS.