### PR TITLE
Use Apache archive URLs so links don't break on new versions

### DIFF
--- a/client_files/apache.sh
+++ b/client_files/apache.sh
@@ -15,21 +15,23 @@ cd ~/sources
 # [1] http://www.us.apache.org/dist//httpd/
 # [2] http://www.us.apache.org/dist//apr
 #
-httpdversion="2.4.16"
-wget "http://www.us.apache.org/dist//httpd/httpd-$httpdversion.tar.gz"
-wget http://www.us.apache.org/dist//apr/apr-1.5.2.tar.gz
-wget http://www.us.apache.org/dist//apr/apr-util-1.5.4.tar.gz
+httpd_version="2.4.16"
+apr_version="1.5.2"
+aprutil_version="1.5.4"
+wget "http://archive.apache.org/dist/httpd/httpd-$httpd_version.tar.gz"
+wget "http://archive.apache.org/dist/apr/apr-$apr_version.tar.gz"
+wget "http://archive.apache.org/dist/apr/apr-util-$aprutil_version.tar.gz"
 
 
 #
 # Unpack and build Apache from source
 #
-tar -zxvf "httpd-$httpdversion.tar.gz"
-tar -zxvf apr-1.5.2.tar.gz
-tar -zxvf apr-util-1.5.4.tar.gz
-cp -r apr-1.5.2 "httpd-$httpdversion/srclib/apr"
-cp -r apr-util-1.5.4 "httpd-$httpdversion/srclib/apr-util"
-cd "httpd-$httpdversion"
+tar -zxvf "httpd-$httpd_version.tar.gz"
+tar -zxvf "apr-$apr_version.tar.gz"
+tar -zxvf "apr-util-$aprutil_version.tar.gz"
+cp -r "apr-$apr_version" "httpd-$httpd_version/srclib/apr"
+cp -r "apr-util-$aprutil_version" "httpd-$httpd_version/srclib/apr-util"
+cd "httpd-$httpd_version"
 ./configure --enable-ssl --enable-so --with-included-apr --with-mpm=event
 make
 make install


### PR DESCRIPTION
Simple change: just use different URLs for Apache sources so they don't break on new versions

Closes #80
Closes #139 (abandons changes)