### PR TITLE
Change Elastic Search extensions repo to gerrit

### DIFF
--- a/client_files/ExtensionSettingsElasticSearch.php
+++ b/client_files/ExtensionSettingsElasticSearch.php
@@ -2,11 +2,11 @@
 # Add 2 extensions required for Elastic Search
 $egExtensionLoaderConfig += array(
 	'Elastica' => array(
-		'git' => 'https://git.wikimedia.org/git/mediawiki/extensions/Elastica.git',
+		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/Elastica.git',
 		'branch' => 'REL1_25',
 	),
 	'CirrusSearch' => array(
-		'git' => 'https://git.wikimedia.org/git/mediawiki/extensions/CirrusSearch.git',
+		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/CirrusSearch.git',
 		'branch' => 'REL1_25',
 	),
 );


### PR DESCRIPTION
In #49 all extensions in the main extension settings file were changed from git.wikimedia.org URLs to gerrit.wikimedia.org. These are faster and more reliable. I just had a test fail due to lack of Elastic Search extensions.