### PR TITLE
Improve wiki "images" directory import

### DIFF
--- a/client_files/import-wiki.sh
+++ b/client_files/import-wiki.sh
@@ -67,18 +67,26 @@ wiki_root="$meza1_root/htdocs/wiki"
 smw_root="$wiki_root/extensions/SemanticMediaWiki"
 wiki_sql_file="$meza1_root/wiki.sql"
 wiki_images="$meza1_root/images.tar.gz"
-cd "$meza1_root/htdocs/wiki"
+cd "$meza1_root"
 
 
-# un-zip images directory
+# untar to new ./images directory
 tar -zxvf "$wiki_images"
-rm ./images/README.md
+
+# remove files from new directory that will be managed by git 
+rm ./images/README
 rm ./images/.htaccess
+
+# move contents of new images directory into wiki images directory
 mv ./images/* "$wiki_root/images/*"
+
+# remove empty directory
+rm -rf ./images
 
 
 # Configure images folder
 # Ref: https://www.mediawiki.org/wiki/Manual:Configuring_file_uploads
+cd "$wiki_root"
 chmod 755 ./images
 chown -R apache:apache ./images
 

--- a/client_files/import-wiki.sh
+++ b/client_files/import-wiki.sh
@@ -7,6 +7,8 @@
 # 1) On your current wiki, create an images.tar.gz file from your wiki's
 #    images directory:
 #    tar -cvzf images.tar.gz ./images/*
+#    If disk space is an issue, you can alternatively just copy the files over
+#    using the instructions below.
 # 
 # 2) Run mysqldump on your wiki and create wiki.sql:
 #    mysqldump -h localhost -u root -p WIKI_DB_NAME > /path/to/save/wiki.sql
@@ -23,13 +25,28 @@
 #    (p)scp /path/to/wiki.sql user@example.com:/var/www/meza1
 #    (p)scp /path/to/images.tar.gz user@example.com:/var/www/meza1
 #    replace "/path/to", "user", and "example.com" accordingly
+# 
+#    To Secure Copy a directory (of images)
+#    scp -r images user@example.com:/var/www/meza1/images
+#
+#    Depending on permissions, you might copy these to a non-root user 
+#    directory first. Then you can move them into a new images
+#    directory /var/www/meza1/images
+#    scp wiki.sql user@example.com:/home/user
+#    scp -r images user@example.com:/home/user/images
+#    Then on the new server:
+#    cd ~
+#    sudo mv wiki.sql /var/www/meza1/wiki.sql
+#    sudo mkdir /var/www/meza1/images
+#    sudo mv ./images/* /var/www/meza1/images
+#    rm -rf ./images
 #
 # 4) Run this script
 
 
 # must be root or sudoer
 if [ "$(whoami)" != "root" ]; then
-	echo "Try running this script with sudo: \"sudo bash install.sh\""
+	echo "Try running this script with sudo: \"sudo bash import-wiki.sh\""
 	exit 1
 fi
 

--- a/client_files/import-wiki.sh
+++ b/client_files/import-wiki.sh
@@ -65,21 +65,21 @@ done
 meza1_root="/var/www/meza1"
 wiki_root="$meza1_root/htdocs/wiki"
 smw_root="$wiki_root/extensions/SemanticMediaWiki"
-wiki_sql_file="$meza1_root/wiki.sql"
-wiki_images="$meza1_root/images"
+imported_sql_file="$meza1_root/wiki.sql"
+imported_images="$meza1_root/images"
 cd "$meza1_root"
 
 
-if [ -d "$wiki_images" ]; then
+if [ -d "$imported_images" ]; then
 	echo "image directory already exists"
-elif [ -f "$wiki_images.tar" ]; then
+elif [ -f "$imported_images.tar" ]; then
 	echo "images.tar found. Extracting..."
-	tar -xvf "$wiki_images.tar"
-	rm -rf "$wiki_images.tar"
-elif [ -f "$wiki_images.tar.gz" ]; then
+	tar -xvf "$imported_images.tar"
+	rm -rf "$imported_images.tar"
+elif [ -f "$imported_images.tar.gz" ]; then
 	echo "images.tar.gz found. Extracting..."
-	tar -zxvf "$wiki_images.tar.gz"
-	rm -rf "$wiki_images.tar.gz"
+	tar -zxvf "$imported_images.tar.gz"
+	rm -rf "$imported_images.tar.gz"
 else
 	echo "No images file or directory found. Exiting..."
 	exit 1
@@ -114,9 +114,9 @@ chown -R apache:apache ./images
 echo "For $wiki_db_name: "
 echo " * dropping if exists"
 echo " * (re)creating"
-echo " * importing file at $wiki_sql_file"
-mysql -u root "--password=$mysql_root_pass" -e"DROP DATABASE IF EXISTS $wiki_db_name; CREATE DATABASE $wiki_db_name; use $wiki_db_name; SOURCE $wiki_sql_file;"
-rm -rf "$wiki_sql_file"
+echo " * importing file at $imported_sql_file"
+mysql -u root "--password=$mysql_root_pass" -e"DROP DATABASE IF EXISTS $wiki_db_name; CREATE DATABASE $wiki_db_name; use $wiki_db_name; SOURCE $imported_sql_file;"
+rm -rf "$imported_sql_file"
 
 # Run update.php. The database you imported may not be up to the same version
 # as Meza1, and thus you must update it.

--- a/client_files/import-wiki.sh
+++ b/client_files/import-wiki.sh
@@ -66,13 +66,25 @@ meza1_root="/var/www/meza1"
 wiki_root="$meza1_root/htdocs/wiki"
 smw_root="$wiki_root/extensions/SemanticMediaWiki"
 wiki_sql_file="$meza1_root/wiki.sql"
-wiki_images="$meza1_root/images.tar.gz"
+wiki_images="$meza1_root/images"
 cd "$meza1_root"
 
 
-# untar to new ./images directory, delete tarball
-tar -zxvf "$wiki_images"
-rm -rf "./images.tar.gz"
+if [ -d "$wiki_images" ]; then
+	echo "image directory already exists"
+elif [ -f "$wiki_images.tar" ]; then
+	echo "images.tar found. Extracting..."
+	tar -xvf "$wiki_images.tar"
+	rm -rf "$wiki_images.tar"
+elif [ -f "$wiki_images.tar.gz" ]; then
+	echo "images.tar.gz found. Extracting..."
+	tar -zxvf "$wiki_images.tar.gz"
+	rm -rf "$wiki_images.tar.gz"
+else
+	echo "No images file or directory found. Exiting..."
+	exit 1
+fi
+
 
 # remove files from new directory that will be managed by git 
 rm ./images/README

--- a/client_files/import-wiki.sh
+++ b/client_files/import-wiki.sh
@@ -70,19 +70,26 @@ wiki_images="$meza1_root/images.tar.gz"
 cd "$meza1_root"
 
 
-# untar to new ./images directory
+# untar to new ./images directory, delete tarball
 tar -zxvf "$wiki_images"
+rm -rf "./images.tar.gz"
 
 # remove files from new directory that will be managed by git 
 rm ./images/README
 rm ./images/.htaccess
 
-# move contents of new images directory into wiki images directory
-mv ./images/* "$wiki_root/images/*"
+# move "good" README and .htaccess to safe location in new images director
+mv "$wiki_root/images/README" ./images/README
+mv "$wiki_root/images/.htaccess" ./images/.htaccess
+
+# remove all contents of wiki images directory
+rm -rf "$wiki_root/images/"*
+
+# move contents of new images directory into wiki images directory (including README, .htaccess)
+mv ./images/* "$wiki_root/images/"
 
 # remove empty directory
 rm -rf ./images
-
 
 # Configure images folder
 # Ref: https://www.mediawiki.org/wiki/Manual:Configuring_file_uploads
@@ -97,7 +104,7 @@ echo " * dropping if exists"
 echo " * (re)creating"
 echo " * importing file at $wiki_sql_file"
 mysql -u root "--password=$mysql_root_pass" -e"DROP DATABASE IF EXISTS $wiki_db_name; CREATE DATABASE $wiki_db_name; use $wiki_db_name; SOURCE $wiki_sql_file;"
-
+rm -rf "$wiki_sql_file"
 
 # Run update.php. The database you imported may not be up to the same version
 # as Meza1, and thus you must update it.


### PR DESCRIPTION
Was overwriting existing README and .htaccess files, then deleting README.md (doesn't exist) and the newly imported .htaccess files. Fixes these issues.

Also adds capability to use images.tar or plain directory, in addition existing images.tar.gz