### PR TITLE
Install Extension:PdfHandler, ImageMagick, Ghostscript and Xpdf

### DIFF
--- a/client_files/ExtensionSettings.php
+++ b/client_files/ExtensionSettings.php
@@ -260,4 +260,15 @@ $egExtensionLoaderConfig += array(
 		'branch' => 'master',
 	),
 
+	'PdfHandler' => array(
+		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/PdfHandler',
+		'branch' => 'REL1_25',
+		'afterFn' => function(){
+			// Location of PdfHandler dependencies
+			$GLOBALS['wgPdfProcessor'] = '/usr/bin/gs'; // installed via yum
+			$GLOBALS['wgPdfPostProcessor'] = '/usr/local/bin/convert'; // built from source
+			$GLOBALS['wgPdfInfo'] = '/usr/local/bin/pdfinfo'; // pre-built binaries installed
+		}
+	),
+
 );

--- a/client_files/LocalSettingsAdditions
+++ b/client_files/LocalSettingsAdditions
@@ -73,3 +73,9 @@ $wgMaxImageArea = 1.25e10; // Images on [[Snorkel]] fail without this
 // If set to 10million, errors are seen when using Edit with form on mission pages like 41S
 // ini_set( 'pcre.backtrack_limit', 10000000 ); //10million
 ini_set( 'pcre.backtrack_limit', 1000000000 ); //1 billion
+
+
+$wgFileExtensions[] = 'pdf';
+$wgFileExtensions[] = 'svg';
+$wgUseImageMagick = true;
+$wgImageMagickConvertCommand = '/usr/local/bin/convert';

--- a/client_files/install-imagick.sh
+++ b/client_files/install-imagick.sh
@@ -2,6 +2,8 @@
 #
 # Install ImageMagick, Ghostscript and Xpdf
 
+print_title "Starting script install-imagick.sh"
+
 
 if [ "$(whoami)" != "root" ]; then
 	echo "Try running this script with sudo: \"sudo bash install-imagick.sh\""
@@ -11,24 +13,29 @@ fi
 #
 # Install Ghostscript
 #
+echo "Installing ghostscript via yum"
 yum -y install ghostscript
 
 
 # Get ImageMagick
-http://www.imagemagick.org/download/ImageMagick.tar.gz
+echo "Downloading and ImageMagick"
+wget http://www.imagemagick.org/download/ImageMagick.tar.gz
 tar xvzf ImageMagick.tar.gz
 
 # Different versions may be downloaded, * to catch whatever version
 cd ImageMagick*
 
-
+echo "Configure ImageMagick"
 ./configure
+echo "Make ImageMagick"
 make
+echo "Make install ImageMagick"
 make install
 
 
 # According to http://www.imagemagick.org/script/install-source.php:
 # "You may need to configure the dynamic linker run-time bindings"
+echo "Configure dynamic linker"
 ldconfig /usr/local/lib
 
 # For testing should run: `make check`
@@ -37,6 +44,7 @@ ldconfig /usr/local/lib
 cd ~
 
 # Get xpdf-utils
+echo "Download xpdf-utils"
 wget ftp://ftp.foolabs.com/pub/xpdf/xpdfbin-linux-3.04.tar.gz
 tar xvzf xpdfbin-linux-3.04.tar.gz
 
@@ -44,10 +52,10 @@ cd xpdfbin-linux-3.04
 
 # Copy correct-architecture executables to /usr/local/bin
 if [ $(uname -m | grep -c 64) -eq 1 ]; then
-	# 64-bit
+	echo "Move 64-bit executables to /usr/local/bin"
 	cp -a ./bin64/. /usr/local/bin/
 else
-	# 32-bit
+	echo "Move 32-bit executables to /usr/local/bin"
 	cp -a ./bin32/. /usr/local/bin/
 fi
 

--- a/client_files/install-imagick.sh
+++ b/client_files/install-imagick.sh
@@ -10,12 +10,6 @@ if [ "$(whoami)" != "root" ]; then
 	exit 1
 fi
 
-#
-# Install Ghostscript
-#
-echo "Installing ghostscript via yum"
-yum -y install ghostscript
-
 
 # Get ImageMagick
 echo "Downloading and ImageMagick"
@@ -26,12 +20,14 @@ tar xvzf ImageMagick.tar.gz
 # Different versions may be downloaded, * to catch whatever version
 cd ImageMagick*
 
+cmd_profile "START build ImageMagick"
 echo "Configure ImageMagick"
 ./configure
 echo "Make ImageMagick"
 make
 echo "Make install ImageMagick"
 make install
+cmd_profile "END build ImageMagick"
 
 
 # According to http://www.imagemagick.org/script/install-source.php:

--- a/client_files/install-imagick.sh
+++ b/client_files/install-imagick.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Install ImageMagick, Ghostscript and Xpdf
+
+
+if [ "$(whoami)" != "root" ]; then
+	echo "Try running this script with sudo: \"sudo bash install-imagick.sh\""
+	exit 1
+fi
+
+#
+# Install Ghostscript
+#
+yum -y install ghostscript
+
+
+# Get ImageMagick
+http://www.imagemagick.org/download/ImageMagick.tar.gz
+tar xvzf ImageMagick.tar.gz
+
+# Different versions may be downloaded, * to catch whatever version
+cd ImageMagick*
+
+
+./configure
+make
+make install
+
+
+# According to http://www.imagemagick.org/script/install-source.php:
+# "You may need to configure the dynamic linker run-time bindings"
+ldconfig /usr/local/lib
+
+# For testing should run: `make check`
+
+
+cd ~
+
+# Get xpdf-utils
+wget ftp://ftp.foolabs.com/pub/xpdf/xpdfbin-linux-3.04.tar.gz
+tar xvzf xpdfbin-linux-3.04.tar.gz
+
+cd xpdfbin-linux-3.04
+
+# Copy correct-architecture executables to /usr/local/bin
+if [ $(uname -m | grep -c 64) -eq 1 ]; then
+	# 64-bit
+	cp -a ./bin64/. /usr/local/bin/
+else
+	# 32-bit
+	cp -a ./bin32/. /usr/local/bin/
+fi
+
+# CentOS does not have /usr/local/man, but xpdf recommends the following
+# copy man pages and sample
+# note: sample is entirely commented out and requires modification
+# cp ./doc/*.1 /usr/local/man/man1
+# cp ./doc/*.5 /usr/local/man/man5
+# cp ./doc/sample-xpdfrc /usr/local/etc/xpdfrc
+

--- a/client_files/install-imagick.sh
+++ b/client_files/install-imagick.sh
@@ -19,6 +19,7 @@ yum -y install ghostscript
 
 # Get ImageMagick
 echo "Downloading and ImageMagick"
+cd ~/sources
 wget http://www.imagemagick.org/download/ImageMagick.tar.gz
 tar xvzf ImageMagick.tar.gz
 
@@ -41,10 +42,9 @@ ldconfig /usr/local/lib
 # For testing should run: `make check`
 
 
-cd ~
-
 # Get xpdf-utils
 echo "Download xpdf-utils"
+cd ~/sources
 wget ftp://ftp.foolabs.com/pub/xpdf/xpdfbin-linux-3.04.tar.gz
 tar xvzf xpdfbin-linux-3.04.tar.gz
 

--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -175,6 +175,9 @@ cd ~/sources/meza1/client_files
 cmd_tee "source yums.sh"
 
 cd ~/sources/meza1/client_files
+cmd_tee "source install-imagick.sh"
+
+cd ~/sources/meza1/client_files
 cmd_tee "source apache.sh"
 
 cd ~/sources/meza1/client_files

--- a/client_files/yums.sh
+++ b/client_files/yums.sh
@@ -105,7 +105,8 @@ yum install -y \
     readline-devel \
     libtidy-devel \
     libmcrypt-devel \
-    pam-devel
+    pam-devel \
+    ghostscript
 cmd_profile "END yum install dependency list"
 
 


### PR DESCRIPTION
Installs ImageMagick, which is the preferred method of handling image files with MediaWiki (rather than the PHP built-in GD). ImageMagick also provides the additional capabilities of:

* Rendering SVGs (though there may be better options, see #117)
* Rendering PDFs as images (using Ghostscript and Xpdf via the [PdfHandler](https://www.mediawiki.org/wiki/Extension:PdfHandler) MediaWiki extension).

Installation of ImageMagick is done from source, since the version available via yum is inadequate (see #18) and no suitable RPMs were available. Ghostscript is installed via yum. Pre-built executables are downloaded for Xpdf.

Closes #18 
