### PR TITLE
Install Extension:PdfHandler and dependencies from install.sh

### DIFF
--- a/client_files/ExtensionSettings.php
+++ b/client_files/ExtensionSettings.php
@@ -260,4 +260,15 @@ $egExtensionLoaderConfig += array(
 		'branch' => 'master',
 	),
 
+	'PdfHandler' => array(
+		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/PdfHandler',
+		'branch' => 'REL1_25',
+		'afterFn' => function(){
+			// Location of PdfHandler dependencies
+			$GLOBALS['wgPdfProcessor'] = '/usr/bin/gs'; // installed via yum
+			$GLOBALS['wgPdfPostProcessor'] = '/usr/local/bin/convert'; // built from source
+			$GLOBALS['wgPdfInfo'] = '/usr/local/bin/pdfinfo'; // pre-built binaries installed
+		}
+	),
+
 );

--- a/client_files/LocalSettingsAdditions
+++ b/client_files/LocalSettingsAdditions
@@ -73,3 +73,9 @@ $wgMaxImageArea = 1.25e10; // Images on [[Snorkel]] fail without this
 // If set to 10million, errors are seen when using Edit with form on mission pages like 41S
 // ini_set( 'pcre.backtrack_limit', 10000000 ); //10million
 ini_set( 'pcre.backtrack_limit', 1000000000 ); //1 billion
+
+
+$wgFileExtensions[] = 'pdf';
+$wgFileExtensions[] = 'svg';
+$wgUseImageMagick = true;
+$wgImageMagickConvertCommand = '/usr/local/bin/convert';

--- a/client_files/install-imagick.sh
+++ b/client_files/install-imagick.sh
@@ -10,12 +10,6 @@ if [ "$(whoami)" != "root" ]; then
 	exit 1
 fi
 
-#
-# Install Ghostscript
-#
-echo "Installing ghostscript via yum"
-yum -y install ghostscript
-
 
 # Get ImageMagick
 echo "Downloading and ImageMagick"
@@ -26,12 +20,14 @@ tar xvzf ImageMagick.tar.gz
 # Different versions may be downloaded, * to catch whatever version
 cd ImageMagick*
 
+cmd_profile "START build ImageMagick"
 echo "Configure ImageMagick"
 ./configure
 echo "Make ImageMagick"
 make
 echo "Make install ImageMagick"
 make install
+cmd_profile "END build ImageMagick"
 
 
 # According to http://www.imagemagick.org/script/install-source.php:

--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -175,6 +175,9 @@ cd ~/sources/meza1/client_files
 cmd_tee "source yums.sh"
 
 cd ~/sources/meza1/client_files
+cmd_tee "source install-imagick.sh"
+
+cd ~/sources/meza1/client_files
 cmd_tee "source apache.sh"
 
 cd ~/sources/meza1/client_files

--- a/client_files/yums.sh
+++ b/client_files/yums.sh
@@ -105,7 +105,8 @@ yum install -y \
     readline-devel \
     libtidy-devel \
     libmcrypt-devel \
-    pam-devel
+    pam-devel \
+    ghostscript
 cmd_profile "END yum install dependency list"
 
 


### PR DESCRIPTION
Dependencies: ImageMagick, Ghostscript, xpdf-utils

ImageMagic is built from source since a more recent version
than what is in yum is required. The yum version of
Ghostscript is sufficient (for now), so it is used. There is
no yum version of xpdf-utils, so a pre-built binary is used.