### PR TITLE
Allow choosing IP address during Vbox setup

### DIFF
--- a/manual/1.0-SettingUpVirtualBox.md
+++ b/manual/1.0-SettingUpVirtualBox.md
@@ -84,21 +84,24 @@ Congratulations! You've successfully installed your virtual machine. Now take a 
 
 ## Setup SSH
 
-Start your VM, then run the following three commands. Unfortunately you have to type them all manually, since your VM doesn't support copy/paste from the host at this point. Type carefully.
+Start your VM, then run the following commands. Unfortunately you have to type them all manually, since your VM doesn't support copy/paste from the host at this point. Type carefully.
 
 ```bash
 ifup eth0
 yum -y install wget
-wget -O - https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/setup.sh | bash
+wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/master/setup.sh
+bash setup.sh
 ```
 
-These three commands do the following:
+These commands do the following:
 
 **ifup eth0** turns on the NAT network adapter, allowing your virtual machine to connect to the internet. Provided you setup your VM as described in [initial setup](manual/1.0-SettingUpVirtualBox.md) this should complete successfully in a couple seconds.
 
 **yum -y install wget** uses the CentOS package manager, yum, to install wget. wget allows your VM to retrieve files from networked resources. In this case we're going to use wget to retrieve a script file from the EnterpriseMediaWiki GitHub repository. This requires about a minute to run.
 
-**wget ... bash** retrieves the setup script file and pipes that script file into bash. This means that the script is executed once it is done downloading. It is recommended that you review the script beforehand to make sure you agree with all actions it takes. This requires about a minute or two to run.
+**wget ... ** retrieves the setup script file.
+
+**bash setup.sh** executes the setup script. If you are not logged in as root, you will need to run this with sudo. This requires about a minute or two to run. (Note that this should prompt you for the desired IP address. If you were to instead pipe this into bash in the same command as the previous wget command, you would not be prompted for the desired IP address. So we run this as a standalone command.)
 
 Once you have run these commands your SSH should work. The IP address of your VM is one of the last lines of output of the wget command. Login from your host machine's terminal (or Putty if you're on Windows). Once you've confirmed you can use SSH it is recommended that you don't use the VM's user interface any longer. Just SSH. When you boot the VM in the future, hold shift while clicking "start" to boot without creating a user interface window.
 

--- a/manual/1.0-SettingUpVirtualBox.md
+++ b/manual/1.0-SettingUpVirtualBox.md
@@ -99,7 +99,7 @@ These commands do the following:
 
 **yum -y install wget** uses the CentOS package manager, yum, to install wget. wget allows your VM to retrieve files from networked resources. In this case we're going to use wget to retrieve a script file from the EnterpriseMediaWiki GitHub repository. This requires about a minute to run.
 
-**wget ... ** retrieves the setup script file.
+**wget https...** retrieves the setup script file.
 
 **bash setup.sh** executes the setup script. If you are not logged in as root, you will need to run this with sudo. This requires about a minute or two to run. (Note that this should prompt you for the desired IP address. If you were to instead pipe this into bash in the same command as the previous wget command, you would not be prompted for the desired IP address. So we run this as a standalone command.)
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,14 @@
 # Setup network configuration for a CentOS 6.6 virtual machine on VirtualBox
 # Please see directions at https://github.com/enterprisemediawiki/meza1
 
+# Get host-only IP address
+while [ -z "$ipaddr" ]
+do
+echo -e "Enter your desired IP address (follow Meza1 VirtualBox Networking steps)"
+read -e -i "192.168.56.56" ipaddr
+done
+
+
 #
 # Load Meza1 repository
 #
@@ -19,14 +27,15 @@ tar xpvf meza1.tar.gz -C ./meza1 --strip-components 1
 #
 cd /etc/sysconfig/network-scripts
 
-ipaddr="192.168.56.56"
-
 # modify ifcfg-eth0 (NAT)
 sed -r -i 's/ONBOOT=no/ONBOOT=yes/g;' ./ifcfg-eth0
 sed -r -i 's/NM_CONTROLLED=yes/NM_CONTROLLED=no/g;' ./ifcfg-eth0
 
 # copy ifcfg-eth1  (host-only)
 cp ~/sources/meza1/client_files/ifcfg-eth1 ./ifcfg-eth1
+
+# modify IP address as required:
+sed -r -i "s/IPADDR=192.168.56.56/IPADDR=$ipaddr/g;" ./ifcfg-eth1
 
 # get eth1 HWADDR from ifconfig, insert int ifcfg-eth1
 eth1_hwaddr="$(ifconfig eth1 | grep '[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}:[a-zA-Z0-9]{2}' -o -P)"


### PR DESCRIPTION
Allows the user to choose an IP address during initial VirtualBox setup (e.g. in `setup.sh`, which I don't think has application except in Vbox VMs at the moment).

Defaults to 192.168.56.56, but can be modified when prompted.