### PR TITLE
Pre built node

### DIFF
--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -33,14 +33,14 @@ cd ~/sources
 # Download binaries
 # Ref: http://derpturkey.com/install-node-js-from-binaries/
 # This doesn't seem to install npm. Perhaps we need to install nvm.
-wget http://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x64.tar.gz
-tar -zxvf node-v0.10.40-linux-x64.tar.gz -C /usr/local/bin
-rm -f node-v0.10.40-linux-x64.tar.gz
+wget http://nodejs.org/dist/v0.12.7/node-v0.12.7-linux-x64.tar.gz
+tar -zxvf node-v0.12.7-linux-x64.tar.gz -C /usr/local/bin
+rm -f node-v0.12.7-linux-x64.tar.gz
 
 # Create a symbolic link for node that points to the new directory
 cd /usr/local/bin
-ln -s node-v0.10.40-linux-x64/bin/node node
-ln -s node-v0.10.40-linux-x64/lib/node_modules/npm/bin/npm-cli.js npm
+ln -s node-v0.12.7-linux-x64.tar.gz/bin/node node
+ln -s node-v0.12.7-linux-x64.tar.gz/lib/node_modules/npm/bin/npm-cli.js npm
 
 if [[ $PATH != *"/usr/local/bin"* ]]; then
 	PATH="/usr/local/bin:$PATH"

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -29,17 +29,18 @@ mw_api_uri="$mw_api_protocol://$mw_api_domain/wiki/api.php"
 echo "******* Downloading node.js *******"
 cd ~/sources
 
-# Download, compile, and install node
-# Ref: https://www.digitalocean.com/community/tutorials/how-to-install-and-run-a-node-js-app-on-centos-6-4-64bit
-wget https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz
-tar zxvf node-v0.12.5.tar.gz
-cd node-v0.12.5
+# Download and install node
+# Ref: https://gist.github.com/isaacs/579814
+mkdir ./node-latest-install
+cd node-latest-install
+wget http://nodejs.org/dist/node-latest.tar.gz
+tar zxvf node-latest.tar.gz --strip-components=1
+rm -f node-latest.tar.gz
 cmd_profile "START node.js build"
 ./configure
-echo "******* Compiling node.js *******"
-make
 echo "******* Installing node.js *******"
 make install
+# curl https://www.npmjs.org/install.sh | sh
 cmd_profile "END node.js build"
 
 # Download and install parsoid

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -39,8 +39,8 @@ rm -f node-v0.12.7-linux-x64.tar.gz
 
 # Create a symbolic link for node that points to the new directory
 cd /usr/local/bin
-ln -s node-v0.12.7-linux-x64.tar.gz/bin/node node
-ln -s node-v0.12.7-linux-x64.tar.gz/lib/node_modules/npm/bin/npm-cli.js npm
+ln -s node-v0.12.7-linux-x64/bin/node node
+ln -s node-v0.12.7-linux-x64/lib/node_modules/npm/bin/npm-cli.js npm
 
 if [[ $PATH != *"/usr/local/bin"* ]]; then
 	PATH="/usr/local/bin:$PATH"

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -39,7 +39,8 @@ rm -f node-v0.10.40-linux-x64.tar.gz
 
 # Create a symbolic link for node that points to the new directory
 cd /usr/local/bin
-ln -s node-v0.10.40-linux-x64 node
+ln -s node-v0.10.40-linux-x64/bin/node node
+ln -s node-v0.10.40-linux-x64/lib/node_modules/npm/bin/npm-cli.js npm
 
 if [[ $PATH != *"/usr/local/bin"* ]]; then
 	PATH="/usr/local/bin:$PATH"

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -32,7 +32,6 @@ cd ~/sources
 
 # Download binaries
 # Ref: http://derpturkey.com/install-node-js-from-binaries/
-# This doesn't seem to install npm. Perhaps we need to install nvm.
 wget http://nodejs.org/dist/v0.12.7/node-v0.12.7-linux-x64.tar.gz
 tar -zxvf node-v0.12.7-linux-x64.tar.gz -C /usr/local/bin
 rm -f node-v0.12.7-linux-x64.tar.gz

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -27,20 +27,22 @@ mw_api_uri="$mw_api_protocol://$mw_api_domain/wiki/api.php"
 
 
 echo "******* Downloading node.js *******"
+cmd_profile "START node.js build"
 cd ~/sources
 
-# Download and install node
-# Ref: https://gist.github.com/isaacs/579814
-mkdir ./node-latest-install
-cd node-latest-install
-wget http://nodejs.org/dist/node-latest.tar.gz
-tar zxvf node-latest.tar.gz --strip-components=1
-rm -f node-latest.tar.gz
-cmd_profile "START node.js build"
-./configure
-echo "******* Installing node.js *******"
-make install
-# curl https://www.npmjs.org/install.sh | sh
+# Download binaries
+# Ref: http://derpturkey.com/install-node-js-from-binaries/
+wget http://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x64.tar.gz
+tar -zxvf node-v0.10.40-linux-x64.tar.gz
+rm -f node-v0.10.40-linux-x64.tar.gz
+
+# Create a symbolic link for node that points to the new directory
+ln -s node-v0.10.40-linux-x64 node
+
+if [[ $PATH != *"/usr/local/bin"* ]]; then
+	PATH="$HOME/sources/node/bin:$PATH"
+fi
+
 cmd_profile "END node.js build"
 
 # Download and install parsoid

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -32,15 +32,17 @@ cd ~/sources
 
 # Download binaries
 # Ref: http://derpturkey.com/install-node-js-from-binaries/
+# This doesn't seem to install npm. Perhaps we need to install nvm.
 wget http://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x64.tar.gz
-tar -zxvf node-v0.10.40-linux-x64.tar.gz
+tar -zxvf node-v0.10.40-linux-x64.tar.gz -C /usr/local/bin
 rm -f node-v0.10.40-linux-x64.tar.gz
 
 # Create a symbolic link for node that points to the new directory
+cd /usr/local/bin
 ln -s node-v0.10.40-linux-x64 node
 
 if [[ $PATH != *"/usr/local/bin"* ]]; then
-	PATH="$HOME/sources/node/bin:$PATH"
+	PATH="/usr/local/bin:$PATH"
 fi
 
 cmd_profile "END node.js build"
@@ -66,7 +68,6 @@ cmd_profile "END npm test parsoid"
 
 # Configure parsoid for wiki use
 # TODO This part can be modified once localsettings.js is included in initial download of files
-# TODO change client_files to master once merged
 # localsettings for parsoid
 echo "******* Downloading configuration files *******"
 cd ~/sources/meza1/client_files


### PR DESCRIPTION
In my last test, parsoid isn't loading:

![image](https://cloud.githubusercontent.com/assets/6728676/9455254/bc0c44d8-4a8e-11e5-8850-b99906cb0f97.png)

When I list the contents of /usr/local/bin, I see the symlinks to node and npm are red. So it seems they are breaking. I might try this again using full paths (`/usr/local/bin/node-v0.12.7-linux-x64.tar.gz/bin/node node`).

Also note the `npm` command was not recognized during script execution:
```
******* Installing parsoid *******
VE.sh: line 60: npm: command not found
******* Testing parsoid *******
VE.sh: line 66: npm: command not found
```
