### PR TITLE
Add samba setup file to share htdocs

### DIFF
--- a/client_files/samba.sh
+++ b/client_files/samba.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Sets up /var/www/meza1/htdocs as a shared drive via samba
+#
+
+echo "Installing samba"
+yum -y install samba samba-client samba-common
+
+chkconfig smb on
+chkconfig nmb on
+
+echo "Setting up iptables rules"
+iptables -I INPUT 4 -m state --state NEW -m udp -p udp --dport 137 -j ACCEPT
+iptables -I INPUT 5 -m state --state NEW -m udp -p udp --dport 138 -j ACCEPT
+iptables -I INPUT 6 -m state --state NEW -m tcp -p tcp --dport 139 -j ACCEPT
+service iptables save
+
+
+cp /etc/samba/smb.conf /etc/samba/smb.conf.bak
+rm /etc/samba/smb.conf
+touch /etc/samba/smb.conf
+
+
+cat > /etc/samba/smb.conf <<- EOM
+#======================= Global Settings =====================================
+[global]
+workgroup = WORKGROUP
+security = share
+map to guest = bad user
+#============================ Share Definitions ==============================
+[MyShare]
+path = /var/www/meza1/htdocs
+browsable =yes
+writable = yes
+guest ok = yes
+read only = no
+EOM
+
+# restart samba services
+service smb restart
+service nmb restart
+
+
+chmod -R 0777 /var/www/meza1/htdocs

--- a/client_files/samba.sh
+++ b/client_files/samba.sh
@@ -3,6 +3,18 @@
 # Sets up /var/www/meza1/htdocs as a shared drive via samba
 #
 
+if [ "$(whoami)" != "root" ]; then
+	echo "Try running this script with sudo: \"sudo bash install.sh\""
+	exit 1
+fi
+
+# If /usr/local/bin is not in PATH then add it
+# Ref enterprisemediawiki/Meza1#68 "Run install.sh with non-root user"
+if [[ $PATH != *"/usr/local/bin"* ]]; then
+	PATH="/usr/local/bin:$PATH"
+fi
+
+
 echo "Installing samba"
 yum -y install samba samba-client samba-common
 

--- a/client_files/samba.sh
+++ b/client_files/samba.sh
@@ -16,7 +16,7 @@ fi
 
 
 echo "Installing samba"
-yum -y install samba samba-client samba-common
+yum -y install samba4 samba4-client samba4-common
 
 chkconfig smb on
 chkconfig nmb on


### PR DESCRIPTION
This sets up a samba share on `/var/www/meza1/htdocs` so you can edit wiki files from your host machine. I did not spend much effort looking into samba settings, so this probably needs to be evaluated for security in general. This is really only intended for developer purposes. I'd just rather work on extensions within the Meza1 system, but be able to edit them from my host machine.