### PR TITLE
Add security to uploads

### DIFF
--- a/client_files/config/LocalSettings.php
+++ b/client_files/config/LocalSettings.php
@@ -52,7 +52,8 @@ require_once "$m_htdocs/wikis/$wikiId/config/setup.php";
 $wgScriptPath = "/$wikiId";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadPath
-$wgUploadPath = "$mezaWikiIP/images";
+// $wgUploadPath = "$mezaWikiIP/images";
+$wgUploadPath = "$wgScriptPath/img_auth.php";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadDirectory
 $wgUploadDirectory = "$m_htdocs/wikis/$wikiId/images";

--- a/client_files/config/LocalSettings.php
+++ b/client_files/config/LocalSettings.php
@@ -40,9 +40,6 @@ if ( ! in_array( $wikiId, $wikis ) ) {
 }
 
 
-// Path of to images and config for this $wikiId
-$mezaWikiIP = "/wikis/$wikiId";
-
 // Get's wiki-specific config variables like:
 // $wgSitename, $mezaAuthType, $mezaDebug, $mezaEnableWikiEmail
 require_once "$m_htdocs/wikis/$wikiId/config/setup.php";
@@ -52,17 +49,16 @@ require_once "$m_htdocs/wikis/$wikiId/config/setup.php";
 $wgScriptPath = "/$wikiId";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadPath
-// $wgUploadPath = "$mezaWikiIP/images";
 $wgUploadPath = "$wgScriptPath/img_auth.php";
 
 // https://www.mediawiki.org/wiki/Manual:$wgUploadDirectory
 $wgUploadDirectory = "$m_htdocs/wikis/$wikiId/images";
 
 // https://www.mediawiki.org/wiki/Manual:$wgLogo
-$wgLogo = "$mezaWikiIP/config/logo.png";
+$wgLogo = "/wikis/$wikiId/config/logo.png";
 
 // https://www.mediawiki.org/wiki/Manual:$wgFavicon
-$wgFavicon = "$mezaWikiIP/config/favicon.ico";
+$wgFavicon = "/wikis/$wikiId/config/favicon.ico";
 
 // https://www.mediawiki.org/wiki/Manual:$wgEmergencyContact
 $wgEmergencyContact = "enterprisemediawiki@gmail.com"; // @todo: this should be in setup, but this is easier for now.

--- a/client_files/config/httpd.conf
+++ b/client_files/config/httpd.conf
@@ -2,20 +2,20 @@
 # This is the main Apache HTTP server configuration file.  It contains the
 # configuration directives that give the server its instructions.
 # See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
-# In particular, see 
+# In particular, see
 # <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
 # for a discussion of each configuration directive.
 #
 # Do NOT simply read the instructions in here without understanding
 # what they do.  They're here only as hints or reminders.  If you are unsure
-# consult the online docs. You have been warned.  
+# consult the online docs. You have been warned.
 #
 # Configuration and logfile names: If the filenames you specify for many
 # of the server's control files begin with "/" (or "drive:/" for Win32), the
 # server will use that explicit path.  If the filenames do *not* begin
 # with "/", the value of ServerRoot is prepended -- so "logs/access_log"
 # with ServerRoot set to "/usr/local/apache2" will be interpreted by the
-# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log" 
+# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log"
 # will be interpreted as '/logs/access_log'.
 
 #
@@ -45,7 +45,7 @@ ServerRoot "/usr/local/apache2"
 # ports, instead of the default. See also the <VirtualHost>
 # directive.
 #
-# Change this to Listen on specific IP addresses as shown below to 
+# Change this to Listen on specific IP addresses as shown below to
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
@@ -151,7 +151,7 @@ LoadModule php5_module        modules/libphp5.so
 <IfModule unixd_module>
 #
 # If you wish httpd to run as a different user or group, you must run
-# httpd as root initially and it will switch.  
+# httpd as root initially and it will switch.
 #
 # User/Group: The name (or #number) of the user/group to run httpd as.
 # It is usually good practice to create a dedicated user and group for
@@ -192,7 +192,7 @@ ServerAdmin you@example.com
 
 #
 # Deny access to the entirety of your server's filesystem. You must
-# explicitly permit access to web content directories in other 
+# explicitly permit access to web content directories in other
 # <Directory> blocks below.
 #
 <Directory />
@@ -239,6 +239,12 @@ DocumentRoot "/var/www/meza1/htdocs"
     # Controls who can get stuff from this server.
     #
     Require all granted
+
+    #
+    # Disable directory browsing
+	#
+	Options All -Indexes
+
 </Directory>
 
 #
@@ -250,8 +256,8 @@ DocumentRoot "/var/www/meza1/htdocs"
 </IfModule>
 
 #
-# The following lines prevent .htaccess and .htpasswd files from being 
-# viewed by Web clients. 
+# The following lines prevent .htaccess and .htpasswd files from being
+# viewed by Web clients.
 #
 <Files ".ht*">
     Require all denied
@@ -304,8 +310,8 @@ LogLevel warn
 
 <IfModule alias_module>
     #
-    # Redirect: Allows you to tell clients about documents that used to 
-    # exist in your server's namespace, but do not anymore. The client 
+    # Redirect: Allows you to tell clients about documents that used to
+    # exist in your server's namespace, but do not anymore. The client
     # will make a new request for the document at its new location.
     # Example:
     # Redirect permanent /foo http://www.example.com/bar
@@ -322,7 +328,7 @@ LogLevel warn
     # the filesystem path.
 
     #
-    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAlias: This controls which directories contain server scripts.
     # ScriptAliases are essentially the same as Aliases, except that
     # documents in the target directory are treated as applications and
     # run by the server when requested rather than as documents sent to the
@@ -425,10 +431,10 @@ LogLevel warn
 #MaxRanges unlimited
 
 #
-# EnableMMAP and EnableSendfile: On systems that support it, 
+# EnableMMAP and EnableSendfile: On systems that support it,
 # memory-mapping or the sendfile syscall may be used to deliver
 # files.  This usually improves server performance, but must
-# be turned off when serving from networked-mounted 
+# be turned off when serving from networked-mounted
 # filesystems or if support for these functions is otherwise
 # broken on your system.
 # Defaults: EnableMMAP On, EnableSendfile Off
@@ -438,9 +444,9 @@ LogLevel warn
 
 # Supplemental configuration
 #
-# The configuration files in the conf/extra/ directory can be 
-# included to add extra features or to modify the default configuration of 
-# the server, or you may simply copy their contents here and change as 
+# The configuration files in the conf/extra/ directory can be
+# included to add extra features or to modify the default configuration of
+# the server, or you may simply copy their contents here and change as
 # necessary.
 
 # Server-pool management (MPM specific)
@@ -519,3 +525,9 @@ SSLRandomSeed connect builtin
         Deny from all
     </FilesMatch>
 </IfModule>
+
+# Don't allow access to images directories. Will allow access via img_auth.php
+<DirectoryMatch "^/var/www/meza1/htdocs/wikis/(.+)/images">
+    Order Allow,Deny
+    Deny From All
+</DirectoryMatch>


### PR DESCRIPTION
This pull request makes it so files cannot be accessed unless the user has access rights to the wiki. Prior to this file security is only provided by the obscurity of file URLs.

**Current status:**

Ready for merge.

**How to test this PR:**

See comment below from @jamesmontalvo3

**List of changes:**

* `$wgUploadPath` now routes all file requests (e.g. requests for images, PDFs, etc) through `img_auth.php`
* `httpd.conf` lots of random white space removed (done automatically by my editor)
* `httpd.conf` blocks direct access images directories

**Issues:**

* Closes #15