### PR TITLE
Explicitly print "import-wikis.sh" rather than script name

### DIFF
--- a/client_files/import-wikis.sh
+++ b/client_files/import-wikis.sh
@@ -52,7 +52,7 @@ fi
 
 
 # print title of script
-bash printTitle.sh "Begin $0"
+bash printTitle.sh "Begin import-wikis.sh"
 
 
 # If /usr/local/bin is not in PATH then add it


### PR DESCRIPTION
In `import-wikis.sh` the echoed title will be "import-wikis.sh" if that script is called directly, which would be the case if someone wanted to actually import wikis. However, `create-wiki.sh` also uses `import-wikis.sh`, so it'll print "create-wiki.sh" in that case (it'll print whatever the parent script is called). Furthermore, during initial install `create-wiki.sh` is called from within either `mediawiki.sh` or `extensions.sh`, which are called from within `install.sh`. Thus, it will display "install.sh" rather than the intended "import-wikis.sh". It's just easier to hard-code it, so that's what this PR does. It's a very minor change.

**Status:** Ready for merge.

**Testing:**

* Normal MediaWiki tests

**Issues:**

* Closes #192 
