### PR TITLE
Improve installer user prompts

### DIFF
--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -37,42 +37,47 @@ read usergithubtoken
 usergithubtoken=${usergithubtoken:-$default_usergithubtoken}
 
 # Prompt user for PHP version
-while [ -z "$phpversion" ]
-do
+default_phpversion="5.4.42"
 echo -e "\nVisit http://php.net/downloads.php for version numbers"
-echo -e "Enter version of PHP you would like (such as 5.4.42) and press [ENTER]: "
-read phpversion
-done
+echo -e "Type the version of PHP you would like (such as 5.4.42) and press [ENTER]:"
+read -e -i $default_phpversion phpversion
+phpversion=${phpversion:-$default_phpversion}
 
-while [ -z "$mysql_root_pass" ]
-do
-echo -e "\nEnter MySQL root password and press [ENTER]: "
-read -s mysql_root_pass
-done
+# Prompt user for MySQL password
+default_mysql_root_pass=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
+echo -e "\nType your desired MySQL root password"
+echo -e "or leave blank for a randomly generated password and press [ENTER]:"
+read mysql_root_pass
+mysql_root_pass=${mysql_root_pass:-$default_mysql_root_pass}
 
-while [ -z "$git_branch" ]
-do
-echo -e "\nEnter git branch of Meza1 you want to use (generally this is \"master\") [ENTER]: "
-read git_branch
-done
+# Prompt user for git branch
+default_git_branch="master"
+echo -e "\nType the git branch of Meza1 you want to use and press [ENTER]:"
+read -e -i $default_git_branch git_branch
+git_branch=${git_branch:-$default_git_branch}
 
-while [ "$mw_api_protocol" != "http" ] && [ "$mw_api_protocol" != "https" ]
-do
-echo -e "\nType http or https for MW API and press [ENTER]: "
-read mw_api_protocol
-done
+# Prompt user for MW API protocol
+default_mw_api_protocol="http"
+echo -e "\nType http or https for MW API and press [ENTER]:"
+read -e -i $default_mw_api_protocol mw_api_protocol
+mw_api_protocol=${mw_api_protocol:-$default_mw_api_protocol}
 
-while [ -z "$mw_api_domain" ]
-do
-echo -e "\nType domain or IP address of your wiki and press [ENTER]: "
-read mw_api_domain
-done
+# Prompt user for MW API Domain or IP address
+FOUNDETH1=`grep "eth1" /proc/net/dev`
+if [ -n "$FOUNDETH1" ]; then
+  default_mw_api_domain=`ifconfig eth1 | grep "inet " | awk -F'[: ]+' '{ print $4 }'`
+else
+  default_mw_api_domain=`ifconfig eth0 | grep "inet " | awk -F'[: ]+' '{ print $4 }'`
+fi
+echo -e "\nType domain or IP address of your wiki and press [ENTER]:"
+read -e -i $default_mw_api_domain mw_api_domain
+mw_api_domain=${mw_api_domain:-$default_mw_api_domain}
 
-while [ -z "$mediawiki_git_install" ]
-do
-echo -e "\nInstall MediaWiki with git? (y/n) [ENTER]: "
-read mediawiki_git_install
-done
+# Prompt user for MW install method
+default_mediawiki_git_install="y"
+echo -e "\nInstall MediaWiki with git? (y/n) [ENTER]:"
+read -e -i $default_mediawiki_git_install mediawiki_git_install
+mediawiki_git_install=${mediawiki_git_install:-$default_mediawiki_git_install}
 
 
 # Check if git installed, and install it if required

--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -47,7 +47,7 @@ phpversion=${phpversion:-$default_phpversion}
 default_mysql_root_pass=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
 echo -e "\nType your desired MySQL root password"
 echo -e "or leave blank for a randomly generated password and press [ENTER]:"
-read mysql_root_pass
+read -s mysql_root_pass
 mysql_root_pass=${mysql_root_pass:-$default_mysql_root_pass}
 
 # Prompt user for git branch

--- a/client_files/install.sh
+++ b/client_files/install.sh
@@ -26,6 +26,12 @@ architecture=32
 fi
 
 
+# Prompt user for git branch
+default_git_branch="master"
+echo -e "\nType the git branch of Meza1 you want to use and press [ENTER]:"
+read -e -i $default_git_branch git_branch
+git_branch=${git_branch:-$default_git_branch}
+
 # Prompt user for GitHub API personal access token
 default_usergithubtoken="e9191bc6d394d64011273d19f4c6be47eb10e25b" # From Oscar Rogers
 echo -e "\nIf you run this script multiple times from one IP address,"
@@ -49,12 +55,6 @@ echo -e "\nType your desired MySQL root password"
 echo -e "or leave blank for a randomly generated password and press [ENTER]:"
 read -s mysql_root_pass
 mysql_root_pass=${mysql_root_pass:-$default_mysql_root_pass}
-
-# Prompt user for git branch
-default_git_branch="master"
-echo -e "\nType the git branch of Meza1 you want to use and press [ENTER]:"
-read -e -i $default_git_branch git_branch
-git_branch=${git_branch:-$default_git_branch}
 
 # Prompt user for MW API protocol
 default_mw_api_protocol="http"


### PR DESCRIPTION
This PR modifies the user prompts at the beginning of install.sh to expedite the user prompt portion.

**List of changes:**
* Generate a random 32-character (upper and lower case) password for MySQL root, but still allow the user to enter something different
* Detect the IP address and suggest that while still allowing the user to enter something different. This checks for eth1 (like our VMs). If there is no eth1, then it pulls the IP address from eth0 (like on our real server).
* For all other prompts, it displays the default value allowing the user to either change the value or just hit enter.

**How to test:**

1. `wget https://raw.githubusercontent.com/enterprisemediawiki/Meza1/detectip/client_files/install.sh`
1. `sudo bash install.sh`
1. Try using defaults vs your own values for the prompts, but the git branch should be `detectip` for this test
1. After the script is complete, do a few standard MW functionality tests

**Issues:**

None