### PR TITLE
Switch ElasticSearch service registration method

### DIFF
--- a/client_files/ElasticSearch.sh
+++ b/client_files/ElasticSearch.sh
@@ -65,7 +65,7 @@ yum -y install elasticsearch
 
 # Configure Elasticsearch to automatically start during bootup
 echo "******* Adding Elasticsearch service *******"
-chkconfig --add elasticsearch
+chkconfig elasticsearch on
 
 # *** MANUAL INSTALLATION OPTION (delete) ***
 # cd ~/sources


### PR DESCRIPTION
Elasticsearch service was being registered in a method different from mysql and httpd services. It worked fine for CentOS 6, but for CentOS 7 it caused the service to not start upon reboot.