### PR TITLE
Add extensions Echo & Thanks

### DIFF
--- a/client_files/ExtensionSettings.php
+++ b/client_files/ExtensionSettings.php
@@ -342,6 +342,7 @@ $egExtensionLoaderConfig += array(
 		'branch' => 'REL1_25',
         'globals' => array(
             'wgEchoEmailFooterAddress' => $GLOBALS['wgPasswordSender'],
+            )
 	),
 
 	'Thanks' => array(

--- a/client_files/ExtensionSettings.php
+++ b/client_files/ExtensionSettings.php
@@ -337,4 +337,14 @@ $egExtensionLoaderConfig += array(
 		},
 	),
 
+	'Echo' => array(
+		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/Echo.git',
+		'branch' => 'REL1_25',
+	),
+
+	'Thanks' => array(
+		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/Thanks.git',
+		'branch' => 'REL1_25',
+	),
+
 );

--- a/client_files/ExtensionSettings.php
+++ b/client_files/ExtensionSettings.php
@@ -340,17 +340,17 @@ $egExtensionLoaderConfig += array(
 	'Echo' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/Echo.git',
 		'branch' => 'REL1_25',
-        'globals' => array(
-            'wgEchoEmailFooterAddress' => $GLOBALS['wgPasswordSender'],
-            )
+		'globals' => array(
+			'wgEchoEmailFooterAddress' => $GLOBALS['wgPasswordSender'],
+		),
 	),
 
 	'Thanks' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/Thanks.git',
 		'branch' => 'REL1_25',
-        'globals' => array(
-            'wgThanksConfirmationRequired' = false;
-            )
+		'globals' => array(
+			'wgThanksConfirmationRequired' => false,
+		),
 	),
 
 );

--- a/client_files/ExtensionSettings.php
+++ b/client_files/ExtensionSettings.php
@@ -348,6 +348,9 @@ $egExtensionLoaderConfig += array(
 	'Thanks' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/Thanks.git',
 		'branch' => 'REL1_25',
+        'globals' => array(
+            'wgThanksConfirmationRequired' = false;
+            )
 	),
 
 );

--- a/client_files/ExtensionSettings.php
+++ b/client_files/ExtensionSettings.php
@@ -340,6 +340,8 @@ $egExtensionLoaderConfig += array(
 	'Echo' => array(
 		'git' => 'https://gerrit.wikimedia.org/r/mediawiki/extensions/Echo.git',
 		'branch' => 'REL1_25',
+        'globals' => array(
+            'wgEchoEmailFooterAddress' => $GLOBALS['wgPasswordSender'],
 	),
 
 	'Thanks' => array(

--- a/client_files/VE.sh
+++ b/client_files/VE.sh
@@ -95,7 +95,6 @@ sed -r -i "s/INSERTED_BY_VE_SCRIPT/$escaped_mw_api_uri/g;" /etc/parsoid/api/loca
 
 
 # Create parsoid user to run parsoid node server
-cd /etc/parsoid # @issue#48: is this necessary?
 useradd parsoid
 
 # Grant parsoid user ownership of /opt/services/parsoid

--- a/client_files/config/LocalSettings.php
+++ b/client_files/config/LocalSettings.php
@@ -258,11 +258,3 @@ $wgImageMagickConvertCommand = '/usr/local/bin/convert';
  **/
 
 include "$m_htdocs/__common/ComposerSettings.php";
-
-/**
- * Echo Settings
- **/
-
-// Use password sender email for Echo emails (or change here to customize)
-// https://www.mediawiki.org/wiki/Extension:Echo#Configuration
-$wgEchoEmailFooterAddress = $wgPasswordSender;

--- a/client_files/config/LocalSettings.php
+++ b/client_files/config/LocalSettings.php
@@ -259,7 +259,10 @@ $wgImageMagickConvertCommand = '/usr/local/bin/convert';
 
 include "$m_htdocs/__common/ComposerSettings.php";
 
+/**
+ * Echo Settings
+ **/
 
-
-
-
+// Use password sender email for Echo emails (or change here to customize)
+// https://www.mediawiki.org/wiki/Extension:Echo#Configuration
+$wgEchoEmailFooterAddress = $wgPasswordSender;


### PR DESCRIPTION
This PR adds extensions Echo and Thanks. I included setting the parameter so that Thanks did not require verification (meaning one-click thanks instead of two-clicks).

It also removes a `cd` command that is unnecessary in the VE script.

## Testing
1. `curl -LO https://raw.githubusercontent.com/enterprisemediawiki/Meza1/echo-thanks/client_files/install.sh`
1. `sudo bash install.sh`
1. Use branch `echo-thanks`

## Issues
Closes #38 
Closes #48