### PR TITLE
Forgot to update branch before merging #186

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ done
 cd ~
 mkdir sources
 cd sources
-curl -L https://github.com/enterprisemediawiki/Meza1/tarball/centos7 > meza1.tar.gz # @FIXME: change to master!!!
+curl -L https://github.com/enterprisemediawiki/Meza1/tarball/master > meza1.tar.gz # @FIXME: change to master!!!
 mkdir meza1
 tar xpvf meza1.tar.gz -C ./meza1 --strip-components 1
 


### PR DESCRIPTION
This is to fix the branch specified in setup.sh - something that was supposed to be fixed before merging #186, but I missed that note once it was ready to merge.